### PR TITLE
Fixed timestamp error

### DIFF
--- a/lib/tcx_builder.py
+++ b/lib/tcx_builder.py
@@ -13,9 +13,7 @@ METERS_PER_MILE = 1609.34
 def getTimeStamp(timeInSeconds):
     timestamp = datetime.fromtimestamp(timeInSeconds, timezone.utc)
     iso = timestamp.isoformat()
-    stepOne = iso.replace("+", ".")
-    split = stepOne.split(":")
-    return "{0}:{1}:{2}{3}Z".format(split[0],split[1],split[2],split[3])
+    return iso.replace("+00:00", ".000Z")
 
 def getHeartRate(heartRate):
     return "{0:.0f}".format(heartRate)


### PR DESCRIPTION
It was converting the timestamp offset (+00:00) to milliseconds.   Milliseconds can only be a precision of 3.  Since the function takes in seconds ms will always be 000.

This was causing an issue with syncing to 3rd parties apps (finalsurge.com) from Garmin.