### PR TITLE
Add Linux Setup and Usage Sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Convert workout data from Peloton into a TCX file that can be uploaded to Garmin
 
-## Setup
+## Windows Setup
 
 1. Download the repo [here](https://github.com/philosowaffle/peloton-to-garmin/archive/master.zip)
 1. Extract the zip file
@@ -15,7 +15,7 @@ Convert workout data from Peloton into a TCX file that can be uploaded to Garmin
 1. Close the command prompt and return to the `peloton-to-garmin` folder
 1. Edit the `config.ini` file and set your Peloton Email and Password, Save and Close
 
-## Usage
+## Windows Usage
 
 * Open a command prompt inside of the `peloton-to-garmin` folder
 * Run the following command:
@@ -23,6 +23,29 @@ Convert workout data from Peloton into a TCX file that can be uploaded to Garmin
 * You will be prompted to enter how many workouts you would like to fetch
 * A TCX file for each workout will be created in the `output` directory
 * The resulting TCX file can then be uploaded to Garmin
+
+## Linux Setup
+
+1. `wget https://github.com/philosowaffle/peloton-to-garmin/archive/master.zip`
+1. `unzip master.zip`
+1. Install [Python 3](https://www.python.org/downloads/) (Windows docs say it works in 3.6.4, Linux tested against 3.8.2)
+1. Navigate so that you are inside the `peloton-to-garmin` folder
+1. From the command prompt run the following command:
+    1. `pip install -r requirements.txt`
+    1. In ubuntu 20.04, if you use the python3 in the repo, the command is `pip3 install -r requirements.txt`
+1. `vim config.ini` (or nano or whatever. Just not emacs, please :P)
+    1. set your Peloton Email and Password, Save and Close
+
+## Linux Usage
+
+* Open a command prompt inside of the `peloton-to-garmin` folder
+* Run the following command:
+    * `python3 peloton-to-garmin.py`
+* You will be prompted to enter how many workouts you would like to fetch
+* A TCX file for each workout will be created in the `output` directory
+* The resulting TCX file can then be uploaded to Garmin
+
+
 
 ## Runnning in docker
 
@@ -32,3 +55,4 @@ Convert workout data from Peloton into a TCX file that can be uploaded to Garmin
     * `docker run -v /full_path_here/peloton-to-garmin/output:/output pelotontogarmin`
 
 ⚠️ WARNING!!! Your username and password for Peloton and Garmin Connect are stored in clear text, WHICH IS NOT SECURE. If you have concerns about storing your credentials in an unsecure file, do not use this option.
+⚠️ WARNING!!! There is no certificate validation. This is open to person-in-the-middle attacks. 


### PR DESCRIPTION
Added a Linux section since the Windows instructions don't work in Linux (wouldn't work on Mac either, but I will leave that for another person/day). Could also use other distributions tested other than Ubuntu 20.04.