### PR TITLE
[23] support expanded activity types on Garmin upload

### DIFF
--- a/lib/tcx_builder.py
+++ b/lib/tcx_builder.py
@@ -35,7 +35,8 @@ def getInstructor(workout):
     return ""
 
 def getGarminActivityType(workout):
-        # Valid Garmin Parent types: Running/Biking/Other
+    # Valid Garmin TCX Sports: Running/Biking/Other
+    # Valid Granular Garmin types: https://github.com/La0/garmin-uploader/blob/master/garmin_uploader/help.txt#L56
     # Peloton Disciplines: cardio, circuit, running, cycling, walking, strength, stretching, meditation, yoga
     fitness_discipline = ""
     try:
@@ -45,15 +46,27 @@ def getGarminActivityType(workout):
 
     if fitness_discipline == "cycling":
         sport = dict(Sport="Biking")
-        simple_garmin_type = "Biking"
-    elif fitness_discipline == "running" or fitness_discipline == "walking":
+        granular_garmin_activity_type = "indoor_cycling"
+    elif fitness_discipline == "running":
         sport = dict(Sport="Running")
-        simple_garmin_type = "Running"
+        granular_garmin_activity_type = "treadmill_running"
+    elif fitness_discipline == "walking":
+        sport = dict(Sport="Running")
+        granular_garmin_activity_type = "walking"
+    elif fitness_discipline == "cardio" or fitness_discipline == "circuit":
+        sport = dict(Sport="Other")
+        granular_garmin_activity_type = "indoor_cardio"
+    elif fitness_discipline == "strength":
+        sport = dict(Sport="Other")
+        granular_garmin_activity_type = "strength_training"
+    elif fitness_discipline == "yoga":
+        sport = dict(Sport="Other")
+        granular_garmin_activity_type = "yoga"
     else:   
         sport = dict(Sport="Other")
-        simple_garmin_type = "Other"
+        granular_garmin_activity_type = "Other"
     
-    return sport, simple_garmin_type
+    return sport, granular_garmin_activity_type
 
 
 def workoutSamplesToTCX(workout, workoutSummary, workoutSamples, outputDir):
@@ -71,12 +84,13 @@ def workoutSamplesToTCX(workout, workoutSummary, workoutSamples, outputDir):
   xsi:schemaLocation="http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2 http://www.garmin.com/xmlschemas/TrainingCenterDatabasev2.xsd"
   xmlns:ns3="http://www.garmin.com/xmlschemas/ActivityExtension/v2"
   xmlns="http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns4="http://www.garmin.com/xmlschemas/ProfileExtension/v1"></TrainingCenterDatabase>""")
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns4="http://www.garmin.com/xmlschemas/ProfileExtension/v1">
+  </TrainingCenterDatabase>""")
 
     activities = etree.Element("Activities")
 
     activity = etree.Element("Activity")
-    sport, simple_garmin_type = getGarminActivityType(workout)
+    sport, granular_garmin_activity_type = getGarminActivityType(workout)
     activity.attrib = sport
 
     activityId = etree.Element("Id")
@@ -243,4 +257,4 @@ def workoutSamplesToTCX(workout, workoutSummary, workoutSamples, outputDir):
 
     outputDir = outputDir.replace("\"", "")
     tree.write(os.path.join(outputDir,filename), xml_declaration=True, encoding="UTF-8", method="xml")
-    return title, filename, simple_garmin_type
+    return title, filename, granular_garmin_activity_type

--- a/peloton-to-garmin.py
+++ b/peloton-to-garmin.py
@@ -66,7 +66,7 @@ class PelotonToGarmin:
 
                     logger.info("Uploading workout to Garmin")
                     fileToUpload = [config.output_directory + "/" + filename]
-                    garminClient.uploadToGarmin(fileToUpload, config.garmin_email, config.garmin_password, str(garmin_activity_type).lower(), title)
+                    garminClient.uploadToGarmin(fileToUpload, config.garmin_email, config.garmin_password, garmin_activity_type.lower(), title)
                     garminUploadHistoryTable.insert({'workoutId': workoutId, 'title': title, 'uploadDt': datetime.now().strftime("%Y-%m-%d %H:%M:%S")})
                 except Exception as e:
                     logger.error("Failed to upload to Garmin: {}".format(e))

--- a/tests/tcx_test_helper.py
+++ b/tests/tcx_test_helper.py
@@ -1,0 +1,55 @@
+from lib import tcx_builder
+
+def assertTcxSportMatches(targetSport, tcx):
+    assert tcx[0][0].attrib["Sport"] == targetSport
+
+def assertTcxIdMatches(workout, tcx):
+    assert tcx[0][0][0].text == tcx_builder.getTimeStamp(workout['start_time'])
+
+def assertTcxLapStartTimeMatches(workout, tcx):
+    assert tcx[0][0][1].attrib["StartTime"] == tcx_builder.getTimeStamp(workout['start_time'])
+
+def assertTcxTotalTimeSecondsMatches(workout, tcx):
+    actual = tcx[0][0][1][0].text 
+    expected = str(workout["ride"]["duration"])
+    assert actual == expected
+
+def assertTcxMaximumSpeedMatches(workoutSummary, tcx):
+    actual = tcx[0][0][1][2].text 
+    expected = tcx_builder.getSpeedInMetersPerSecond(workoutSummary["max_speed"])
+    assert actual == expected
+
+def assertTcxCaloriesMatches(workoutSummary, tcx):
+    actual = tcx[0][0][1][3].text 
+    expected = str(int(round((workoutSummary["calories"]))))
+    assert actual == expected
+
+def assertTcxAvgHeartRateMatches(workoutSummary,tcx):
+    actual = tcx[0][0][1][4][0].text 
+    expected = tcx_builder.getHeartRate(workoutSummary["avg_heart_rate"])
+    assert actual == expected
+
+def assertTcxMaxHeartRateMatches(workoutSummary, tcx):
+    actual = tcx[0][0][1][5][0].text 
+    expected = tcx_builder.getHeartRate(workoutSummary["max_heart_rate"])
+    assert actual == expected
+
+def assertTcxAvgSpeedMatches(workoutSummary, tcx):
+    actual = tcx[0][0][1][7][0][0].text 
+    expected = tcx_builder.getSpeedInMetersPerSecond(workoutSummary["avg_speed"])
+    assert actual == expected
+
+def assertTcxMaxBikeCadenceMatches(workoutSummary, tcx):
+    actual = tcx[0][0][1][7][0][1].text 
+    expected = tcx_builder.getCadence(workoutSummary["max_cadence"])
+    assert actual == expected
+
+def assertTcxAvgWattsMatches(workoutSummary, tcx):
+    actual = tcx[0][0][1][7][0][2].text 
+    expected = "{0:.0f}".format(workoutSummary["avg_power"])
+    assert actual == expected
+
+def assertTcxMaxWattsMatches(workoutSummary, tcx):
+    actual = tcx[0][0][1][7][0][3].text 
+    expected = "{0:.0f}".format(workoutSummary["max_power"])
+    assert actual == expected

--- a/tests/test_tcx_builder.py
+++ b/tests/test_tcx_builder.py
@@ -1,5 +1,7 @@
 import json
 import os
+import tests.tcx_test_helper as TCX
+import xml.etree.ElementTree as ET
 from lib import tcx_builder
 
 class TestTcxBuilder:
@@ -17,6 +19,10 @@ class TestTcxBuilder:
     def getOutputDir(self):
         return os.path.join(os.getcwd(),"testOutput")
 
+    def loadOutputTCX(self, filepath):
+        tree = ET.parse(filepath)
+        return tree.getroot()
+
     def test_cycling_smoketest(self):
         # Setup
         workout_data = self.loadTestData("peloton_workout_cycling.json")
@@ -30,8 +36,21 @@ class TestTcxBuilder:
         # Assert
         assert title == "20 min HIIT Ride with Denis Morton"
         assert filename == "1586208689-20 min HIIT Ride with Denis Morton-6c4d525d20134c74b7395991ed6912ce.tcx"
-        assert garmin_activity_type == "Biking"
+        assert garmin_activity_type == "indoor_cycling"
         assert os.path.exists(os.path.join(output_directory, filename))
+
+        tcx = self.loadOutputTCX(os.path.join(output_directory, filename))
+        TCX.assertTcxSportMatches("Biking", tcx)
+        TCX.assertTcxIdMatches(workout_data, tcx)
+        TCX.assertTcxLapStartTimeMatches(workout_data, tcx)
+        TCX.assertTcxTotalTimeSecondsMatches(workout_data, tcx)
+        TCX.assertTcxMaximumSpeedMatches(workout_summary, tcx)
+        TCX.assertTcxCaloriesMatches(workout_summary, tcx)
+        TCX.assertTcxAvgHeartRateMatches(workout_summary,tcx)
+        TCX.assertTcxAvgSpeedMatches(workout_summary, tcx)
+        TCX.assertTcxMaxBikeCadenceMatches(workout_summary, tcx)
+        TCX.assertTcxAvgWattsMatches(workout_summary, tcx)
+        TCX.assertTcxMaxWattsMatches(workout_summary, tcx)
 
     def test_cycling_freestyle_smoketest(self):
         # Setup
@@ -46,8 +65,22 @@ class TestTcxBuilder:
         # Assert
         assert title == "27 sec Just Ride"
         assert filename == "1595374979-27 sec Just Ride-88963f6daf89445387da4ee2e26015f9.tcx"
-        assert garmin_activity_type == "Biking"
+        assert garmin_activity_type == "indoor_cycling"
         assert os.path.exists(os.path.join(output_directory, filename))
+
+        tcx = self.loadOutputTCX(os.path.join(output_directory, filename))
+        TCX.assertTcxSportMatches("Biking", tcx)
+        TCX.assertTcxIdMatches(workout_data, tcx)
+        TCX.assertTcxLapStartTimeMatches(workout_data, tcx)
+        TCX.assertTcxTotalTimeSecondsMatches(workout_data, tcx)
+        TCX.assertTcxMaximumSpeedMatches(workout_summary, tcx)
+        TCX.assertTcxCaloriesMatches(workout_summary, tcx)
+        TCX.assertTcxAvgHeartRateMatches(workout_summary,tcx)
+        TCX.assertTcxAvgSpeedMatches(workout_summary, tcx)
+        TCX.assertTcxMaxBikeCadenceMatches(workout_summary, tcx)
+        TCX.assertTcxAvgWattsMatches(workout_summary, tcx)
+        TCX.assertTcxMaxWattsMatches(workout_summary, tcx)
+
 
     def test_strength_smoketest(self):
         # Setup
@@ -62,8 +95,22 @@ class TestTcxBuilder:
         # Assert
         assert title == "10 min Bodyweight Strength with Becs Gentry"
         assert filename == "1589907174-10 min Bodyweight Strength with Becs Gentry-38583cbc0e434e54a2eb91be1a770e01.tcx"
-        assert garmin_activity_type == "Other"
+        assert garmin_activity_type == "strength_training"
         assert os.path.exists(os.path.join(output_directory, filename))
+
+        tcx = self.loadOutputTCX(os.path.join(output_directory, filename))
+        TCX.assertTcxSportMatches("Other", tcx)
+        TCX.assertTcxIdMatches(workout_data, tcx)
+        TCX.assertTcxLapStartTimeMatches(workout_data, tcx)
+        TCX.assertTcxTotalTimeSecondsMatches(workout_data, tcx)
+        TCX.assertTcxMaximumSpeedMatches(workout_summary, tcx)
+        TCX.assertTcxCaloriesMatches(workout_summary, tcx)
+        TCX.assertTcxAvgHeartRateMatches(workout_summary,tcx)
+        TCX.assertTcxAvgSpeedMatches(workout_summary, tcx)
+        TCX.assertTcxMaxBikeCadenceMatches(workout_summary, tcx)
+        TCX.assertTcxAvgWattsMatches(workout_summary, tcx)
+        TCX.assertTcxMaxWattsMatches(workout_summary, tcx)
+
 
     def test_running_smoketest(self):
         # Setup
@@ -78,8 +125,22 @@ class TestTcxBuilder:
         # Assert
         assert title == "20 min Pop Fun Run with Olivia Amato"
         assert filename == "1565299850-20 min Pop Fun Run with Olivia Amato-63eef26a23744af295f14006811b159b.tcx"
-        assert garmin_activity_type == "Running"
+        assert garmin_activity_type == "treadmill_running"
         assert os.path.exists(os.path.join(output_directory, filename))
+
+        tcx = self.loadOutputTCX(os.path.join(output_directory, filename))
+        TCX.assertTcxSportMatches("Running", tcx)
+        TCX.assertTcxIdMatches(workout_data, tcx)
+        TCX.assertTcxLapStartTimeMatches(workout_data, tcx)
+        TCX.assertTcxTotalTimeSecondsMatches(workout_data, tcx)
+        TCX.assertTcxMaximumSpeedMatches(workout_summary, tcx)
+        TCX.assertTcxCaloriesMatches(workout_summary, tcx)
+        TCX.assertTcxAvgHeartRateMatches(workout_summary,tcx)
+        TCX.assertTcxAvgSpeedMatches(workout_summary, tcx)
+        TCX.assertTcxMaxBikeCadenceMatches(workout_summary, tcx)
+        TCX.assertTcxAvgWattsMatches(workout_summary, tcx)
+        TCX.assertTcxMaxWattsMatches(workout_summary, tcx)
+
     
     def test_running_outdoor_smoketest(self):
         # Setup
@@ -94,5 +155,18 @@ class TestTcxBuilder:
         # Assert
         assert title == "20 min Walk + Run with Olivia Amato"
         assert filename == "1574980432-20 min Walk + Run with Olivia Amato-af25d72ea4c0400daeac2707fc30994f.tcx"
-        assert garmin_activity_type == "Running"
+        assert garmin_activity_type == "walking"
         assert os.path.exists(os.path.join(output_directory, filename))
+
+        tcx = self.loadOutputTCX(os.path.join(output_directory, filename))
+        TCX.assertTcxSportMatches("Running", tcx)
+        TCX.assertTcxIdMatches(workout_data, tcx)
+        TCX.assertTcxLapStartTimeMatches(workout_data, tcx)
+        TCX.assertTcxTotalTimeSecondsMatches(workout_data, tcx)
+        TCX.assertTcxMaximumSpeedMatches(workout_summary, tcx)
+        TCX.assertTcxCaloriesMatches(workout_summary, tcx)
+        TCX.assertTcxAvgHeartRateMatches(workout_summary,tcx)
+        TCX.assertTcxAvgSpeedMatches(workout_summary, tcx)
+        TCX.assertTcxMaxBikeCadenceMatches(workout_summary, tcx)
+        TCX.assertTcxAvgWattsMatches(workout_summary, tcx)
+        TCX.assertTcxMaxWattsMatches(workout_summary, tcx)


### PR DESCRIPTION
#23 

* Raw TCX format does not support expanded activity types
* To change an activity type you must make an additional api call to Garmin to modify the activity type after uploading a TCX
* This is handled by the client library we are using for garmin upload
* Added support to map new types on upload
* Added additional unit tests