### PR TITLE
Optimize GarminClient usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,4 +110,3 @@ output/
 tests/testOutput/
 tests/database.json
 bak_config.ini
-.vscode/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -38,7 +38,7 @@
             "name": "Python: All debug Options",
             "type": "python",
             "request": "launch",
-            "pythonPath": "${config:python.pythonPath}",
+            "pythonPath": "${command:python.interpreterPath}",
             "program": "${file}",
             "module": "module.name",
             "env": {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "python.jediEnabled": false
+    "python.jediEnabled": false,
+    "python.languageServer": "Microsoft"
 }

--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ Various config and upload history is maintained in a local `database.json` file.
 
 Special thanks to all the [contributors](https://github.com/philosowaffle/peloton-to-garmin/graphs/contributors) who have helped improve this project!
 
+Garmin Upload feature is provided by the library: https://github.com/La0/garmin-uploader
+
 ## Warnings
 
 ⚠️ WARNING!!! Your username and password for Peloton and Garmin Connect are stored in clear text, WHICH IS NOT SECURE. If you have concerns about storing your credentials in an unsecure file, do not use this option.

--- a/lib/garminClient.py
+++ b/lib/garminClient.py
@@ -1,16 +1,59 @@
 import logging
+import time
+from datetime import datetime
 from garmin_uploader.workflow import Workflow
+from garmin_uploader.workflow import User
+from garmin_uploader.workflow import Activity
 
 ##############################
 # Logging Setup
 ##############################
 
-logger = logging.getLogger('peloton-to-garmin.garminClient')
+class GarminClient:
 
-def uploadToGarmin(paths, garminUsername, garminPassword, activityType, activityName):
-    try:
-        workflow = Workflow(paths, garminUsername, garminPassword, activityType, activityName)
-        workflow.run()
-    except Exception as e:
-        logger.error("Failed to upload to Garmin Connect. - {}".format(e)) 
-        raise e
+    """Main Garmin Api Class"""
+    def __init__(self, user_email, user_password):
+        self.logger = logging.getLogger('peloton-to-garmin.garminClient')
+
+        if user_email is None:
+            self.logger.error("Please specify your Garmin login email.")
+            raise "Please specify your Garmin login email."
+            
+        if user_password is None:
+            self.logger.error("Please specify your Garmin login password.")
+            raise "Please specify your Garmin login password."
+
+        self.user = User(user_email, user_password)
+        self.activities = {}
+        self.last_request = 0.0
+
+    def addActivity(self, path, activityType, activityName, activityId):
+        self.activities[activityId] = Activity(path, activityName, activityType)
+
+    def uploadToGarmin(self, uploadHistoryTable):
+        if not self.user.authenticate():
+            self.logger.error("Failed to authenticate garmin user.")
+            raise Exception("Failed to authenticate garmin user.")
+
+        for activityId in self.activities:
+            try:
+                self.rate_limit()
+                self.activities[activityId].upload(self.user)
+                activityName = self.activities[activityId].name
+                uploadHistoryTable.insert({'workoutId': activityId, 'title': activityName, 'uploadDt': datetime.now().strftime("%Y-%m-%d %H:%M:%S")})
+                self.logger.info("Uploaded activity: {}".format(activityName))
+            except Exception as e:
+                self.logger.error("Failed to upload activity: {} to Garmin Connect with error {}".format(activityName, e))
+
+    def rate_limit(self):
+        min_period = 1
+        if not self.last_request:
+            self.last_request = 0.0
+
+        wait_time = max(0, min_period - (time.time() - self.last_request))
+        if wait_time <= 0:
+            return
+        time.sleep(wait_time)
+
+        self.last_request = time.time()
+        self.logger.debug("Rate limited for %f" % wait_time)

--- a/lib/garminClient.py
+++ b/lib/garminClient.py
@@ -15,8 +15,8 @@ class GarminClient:
     def __init__(self, user_email, user_password):
         self.logger = logging.getLogger('peloton-to-garmin.garminClient')
 
-        assert user_email is not None and user_email is not "", "Please specify your Garmin login email."
-        assert user_password is not None and user_password is not "", "Please specify your Garmin login password."
+        assert user_email is not None and user_email != "", "Please specify your Garmin login email."
+        assert user_password is not None and user_password != "", "Please specify your Garmin login password."
 
         self.user = User(user_email, user_password)
         self.activities = {}

--- a/lib/garminClient.py
+++ b/lib/garminClient.py
@@ -15,13 +15,8 @@ class GarminClient:
     def __init__(self, user_email, user_password):
         self.logger = logging.getLogger('peloton-to-garmin.garminClient')
 
-        if user_email is None:
-            self.logger.error("Please specify your Garmin login email.")
-            raise "Please specify your Garmin login email."
-            
-        if user_password is None:
-            self.logger.error("Please specify your Garmin login password.")
-            raise "Please specify your Garmin login password."
+        assert user_email is not None and user_email is not "", "Please specify your Garmin login email."
+        assert user_password is not None and user_password is not "", "Please specify your Garmin login password."
 
         self.user = User(user_email, user_password)
         self.activities = {}
@@ -31,9 +26,7 @@ class GarminClient:
         self.activities[activityId] = Activity(path, activityName, activityType)
 
     def uploadToGarmin(self, uploadHistoryTable):
-        if not self.user.authenticate():
-            self.logger.error("Failed to authenticate garmin user.")
-            raise Exception("Failed to authenticate garmin user.")
+        assert self.user.authenticate(), "Failed to authenticate garmin user."
 
         for activityId in self.activities:
             try:
@@ -56,4 +49,4 @@ class GarminClient:
         time.sleep(wait_time)
 
         self.last_request = time.time()
-        self.logger.debug("Rate limited for %f" % wait_time)
+        self.logger.debug("Rate limiting for %f" % wait_time)

--- a/lib/pelotonApi.py
+++ b/lib/pelotonApi.py
@@ -8,13 +8,8 @@ class PelotonApi:
     def __init__(self, user_email, user_password):
         self.logger = logging.getLogger('peloton-to-garmin.PelotonApi')
 
-        if user_email is None:
-            self.logger.error("Please specify your Peloton login email.")
-            raise "Please specify your Peloton login email."
-        
-        if user_password is None:
-            self.logger.error("Please specify your Peloton login password.")
-            raise "Please specify your Peloton login password."
+        assert user_email is not None and user_email is not "", "Please specify your Peloton login email."
+        assert user_password is not None and user_password is not "", "Please specify your Peloton login password."
 
         self.http_base = "https://api.pelotoncycle.com/api/"
         self.session = requests.Session()

--- a/lib/pelotonApi.py
+++ b/lib/pelotonApi.py
@@ -8,8 +8,8 @@ class PelotonApi:
     def __init__(self, user_email, user_password):
         self.logger = logging.getLogger('peloton-to-garmin.PelotonApi')
 
-        assert user_email is not None and user_email is not "", "Please specify your Peloton login email."
-        assert user_password is not None and user_password is not "", "Please specify your Peloton login password."
+        assert user_email is not None and user_email != "", "Please specify your Peloton login email."
+        assert user_password is not None and user_password != "", "Please specify your Peloton login password."
 
         self.http_base = "https://api.pelotoncycle.com/api/"
         self.session = requests.Session()

--- a/peloton-to-garmin.py
+++ b/peloton-to-garmin.py
@@ -35,7 +35,7 @@ class PelotonToGarmin:
         workouts = pelotonClient.getXWorkouts(numActivities)
 
         if config.uploadToGarmin:
-            garminUploader = garminClient.garminUploader(config.garmin_email, config.garmin_password)
+            garminUploader = garminClient.GarminClient(config.garmin_email, config.garmin_password)
         
         for w in workouts:
             workoutId = w["id"]
@@ -68,7 +68,7 @@ class PelotonToGarmin:
                         continue
 
                     logger.info("Queing activity for upload: {}".format(title))
-                    fileToUpload = [config.output_directory + "/" + filename]
+                    fileToUpload = config.output_directory + "/" + filename
                     garminUploader.addActivity(fileToUpload, garmin_activity_type.lower(), title, workoutId)
                 except Exception as e:
                     logger.error("Failed to queue activity for Garmin upload: {}".format(e))

--- a/tests/test_garminClient.py
+++ b/tests/test_garminClient.py
@@ -23,7 +23,7 @@ class TestGarminClient:
         with pytest.raises(AssertionError) as err:
             garminUploader = garminClient.GarminClient(user_email, user_password)
         
-        if user_email is None or user_email is "":
+        if user_email is None or user_email == "":
             assert "email" in str(err.value)
         else:
             assert "password" in str(err.value)

--- a/tests/test_garminClient.py
+++ b/tests/test_garminClient.py
@@ -1,0 +1,54 @@
+import json
+import os
+import importlib
+import pytest
+from lib import garminClient
+
+class TestGarminClient:
+    
+    @classmethod
+    def setup_class(cls):
+        return
+
+    client_throws_when_missing_required_fields_testdata = [
+        (None, "pwd"),
+        ("", "pwd"),
+        ("email", None),
+        ("email", ""),
+        (None, None),
+        ("", "")
+    ]
+    @pytest.mark.parametrize("user_email, user_password", client_throws_when_missing_required_fields_testdata)
+    def test_client_throws_when_missing_required_fields(self, user_email, user_password):
+        with pytest.raises(AssertionError) as err:
+            garminUploader = garminClient.GarminClient(user_email, user_password)
+        
+        if user_email is None or user_email is "":
+            assert "email" in str(err.value)
+        else:
+            assert "password" in str(err.value)
+    
+    def test_addActivity_adds_activity(self):
+        # Setup
+        garminUploader = garminClient.GarminClient("email", "pwd")
+
+        # Act
+        garminUploader.addActivity("some/path", "someType", "someName01", "someId01")
+        garminUploader.addActivity("some/path", "someType", "someName02", "someId02")
+
+        # Assert
+        assert len(garminUploader.activities) == 2
+
+        assert garminUploader.activities["someId01"].name == "someName01"
+        assert garminUploader.activities["someId02"].name == "someName02"
+
+    def test_uploadActivity_when_auth_fails_throws(self, mocker):
+        # Setup
+        garminUploader = garminClient.GarminClient("email", "pwd")
+
+        # Act
+        with pytest.raises(AssertionError) as err:
+            garminUploader.uploadToGarmin(None)
+
+        # Assert
+        assert "Failed to authenticate garmin user." in str(err.value)


### PR DESCRIPTION
Current implementation will re-authenticate for every upload.  When uploading a large set of workouts that means we will re-authenticate each time and currently will not take advantage of avoiding rate limiting.

Current flow:
1. Fetch all workouts from Peloton
2. Iterate over workouts one by one, first write a TCX file, then upload to Garmin

New flow:
1. Fetch all workouts from Peloton
2. Iterate over workouts one by one and write TCX file, add workout to an upload queue
3. Authenticate with Garmin once then proceed to upload each queued workout, pausing as needed to avoid hitting Garmin rate limits