### PR TITLE
[41] explicitly set total work to match value from peloton summary

### DIFF
--- a/lib/tcx_builder.py
+++ b/lib/tcx_builder.py
@@ -150,6 +150,9 @@ def workoutSamplesToTCX(workout, workoutSummary, workoutSamples, outputDir):
     intensity = etree.Element("Intensity")
     intensity.text = "Active"
 
+    triggerMethod = etree.Element("TriggerMethod")
+    triggerMethod.text = "Manual"
+
     instructor = getInstructor(workout)
     rideTitle = unidecode(workout["ride"]["title"].replace("/","-").replace(":","-"))
     title = "{0}{1}".format(rideTitle, instructor)
@@ -181,22 +184,34 @@ def workoutSamplesToTCX(workout, workoutSummary, workoutSamples, outputDir):
         maximumHeartRateBpm.append(mhrbValue)
 
         extensions = etree.Element("Extensions")
-        lx = etree.Element("{http://www.garmin.com/xmlschemas/ActivityExtension/v2}LX")
+        lx = etree.Element("{http://www.garmin.com/xmlschemas/ActivityExtension/v2}TPX")
 
-        avgSpeed = etree.Element("{http://www.garmin.com/xmlschemas/ActivityExtension/v2}AvgSpeed")
-        avgSpeed.text = str(getAverageSpeedMetersPerSecond(workoutSamples, originalDistanceUnit))
+        totalPower = etree.Element("{http://www.garmin.com/xmlschemas/ActivityExtension/v2}TotalPower")
+        totalPower.text = "{0:.0f}".format(workoutSummary["total_work"])
 
-        maxBikeCadence = etree.Element("{http://www.garmin.com/xmlschemas/ActivityExtension/v2}MaxBikeCadence")
+        maxBikeCadence = etree.Element("{http://www.garmin.com/xmlschemas/ActivityExtension/v2}MaximumCadence")
         maxBikeCadence.text = getCadence(workoutSummary["max_cadence"])
 
-        avgWatts = etree.Element("{http://www.garmin.com/xmlschemas/ActivityExtension/v2}AvgWatts")
+        avgCadence = etree.Element("{http://www.garmin.com/xmlschemas/ActivityExtension/v2}AverageCadence")
+        avgCadence.text = "{0:.0f}".format(workoutSummary["avg_cadence"])
+
+        avgWatts = etree.Element("{http://www.garmin.com/xmlschemas/ActivityExtension/v2}AverageWatts")
         avgWatts.text = "{0:.0f}".format(workoutSummary["avg_power"])
 
-        maxWatts = etree.Element("{http://www.garmin.com/xmlschemas/ActivityExtension/v2}MaxWatts")
+        maxWatts = etree.Element("{http://www.garmin.com/xmlschemas/ActivityExtension/v2}MaximumWatts")
         maxWatts.text = "{0:.0f}".format(workoutSummary["max_power"])
 
-        lx.append(avgSpeed)
+        avgResistance = etree.Element("{http://www.garmin.com/xmlschemas/ActivityExtension/v2}AverageResistance")
+        avgResistance.text = "{0:.0f}".format(workoutSummary["avg_resistance"])
+
+        maxResistance = etree.Element("{http://www.garmin.com/xmlschemas/ActivityExtension/v2}MaximumResistance")
+        maxResistance.text = "{0:.0f}".format(workoutSummary["max_resistance"])
+
+        lx.append(totalPower)
+        lx.append(avgCadence)
         lx.append(maxBikeCadence)
+        lx.append(avgResistance)
+        lx.append(maxResistance)
         lx.append(avgWatts)
         lx.append(maxWatts)
         extensions.append(lx)
@@ -295,16 +310,17 @@ def workoutSamplesToTCX(workout, workoutSummary, workoutSamples, outputDir):
     lap.append(totalTimeSeconds)
     lap.append(distanceMeters)
     lap.append(maximumSpeed)
-    lap.append(calories)
     lap.append(averageHeartRateBpm)
     lap.append(maximumHeartRateBpm)
-    lap.append(track)
-    lap.append(extensions)
+    lap.append(calories)
     lap.append(intensity)
+    lap.append(triggerMethod)
+    lap.append(extensions)    
+    lap.append(track)
 
     activity.append(activityId)
-    activity.append(lap)
     activity.append(notes)
+    activity.append(lap)
 
     activities.append(activity)
     root.append(activities)

--- a/tests/tcx_test_helper.py
+++ b/tests/tcx_test_helper.py
@@ -7,51 +7,75 @@ def assertTcxIdMatches(workout, tcx):
     assert tcx[0][0][0].text == tcx_builder.getTimeStamp(workout['start_time'])
 
 def assertTcxLapStartTimeMatches(workout, tcx):
-    assert tcx[0][0][1].attrib["StartTime"] == tcx_builder.getTimeStamp(workout['start_time'])
+    assert tcx[0][0][2].attrib["StartTime"] == tcx_builder.getTimeStamp(workout['start_time'])
 
 def assertTcxTotalTimeSecondsMatches(workout, tcx):
-    actual = tcx[0][0][1][0].text 
+    actual = tcx[0][0][2][0].text 
     expected = str(workout["ride"]["duration"])
     assert actual == expected
 
 def assertTcxMaximumSpeedMatches(workoutSamples, tcx):
-    actual = tcx[0][0][1][2].text
+    actual = tcx[0][0][2][2].text
     _, originalDistanceUnit = tcx_builder.getDistanceMeters(workoutSamples) 
     expected = str(tcx_builder.getMaxSpeedMetersPerSecond(workoutSamples, originalDistanceUnit))
     assert actual == expected
 
 def assertTcxCaloriesMatches(workoutSummary, tcx):
-    actual = tcx[0][0][1][3].text 
+    actual = tcx[0][0][2][5].text 
     expected = str(int(round((workoutSummary["calories"]))))
     assert actual == expected
 
 def assertTcxAvgHeartRateMatches(workoutSummary,tcx):
-    actual = tcx[0][0][1][4][0].text 
+    actual = tcx[0][0][2][3][0].text 
     expected = tcx_builder.getHeartRate(workoutSummary["avg_heart_rate"])
     assert actual == expected
 
 def assertTcxMaxHeartRateMatches(workoutSummary, tcx):
-    actual = tcx[0][0][1][5][0].text 
+    actual = tcx[0][0][2][4][0].text 
     expected = tcx_builder.getHeartRate(workoutSummary["max_heart_rate"])
     assert actual == expected
 
-def assertTcxAvgSpeedMatches(workoutSamples, tcx):
-    actual = tcx[0][0][1][7][0][0].text 
-    _, originalDistanceUnit = tcx_builder.getDistanceMeters(workoutSamples) 
-    expected = str(tcx_builder.getAverageSpeedMetersPerSecond(workoutSamples, originalDistanceUnit))
-    assert actual == expected
-
 def assertTcxMaxBikeCadenceMatches(workoutSummary, tcx):
-    actual = tcx[0][0][1][7][0][1].text 
+    actual = tcx[0][0][2][8][0][2].text 
     expected = tcx_builder.getCadence(workoutSummary["max_cadence"])
     assert actual == expected
 
 def assertTcxAvgWattsMatches(workoutSummary, tcx):
-    actual = tcx[0][0][1][7][0][2].text 
+    actual = tcx[0][0][2][8][0][5].text 
     expected = "{0:.0f}".format(workoutSummary["avg_power"])
     assert actual == expected
 
 def assertTcxMaxWattsMatches(workoutSummary, tcx):
-    actual = tcx[0][0][1][7][0][3].text 
+    actual = tcx[0][0][2][8][0][6].text 
     expected = "{0:.0f}".format(workoutSummary["max_power"])
+    assert actual == expected
+
+def assertTcxTotalPowerMatches(workoutSummary, tcx):
+    actual = tcx[0][0][2][8][0][0].text 
+    expected = "{0:.0f}".format(workoutSummary["total_work"])
+    assert actual == expected
+
+def assertTcxAvgBikeCadenceMatches(workoutSummary, tcx):
+    actual = tcx[0][0][2][8][0][1].text 
+    expected = "{0:.0f}".format(workoutSummary["avg_cadence"])
+    assert actual == expected
+
+def assertTcxAvgResistanceMatches(workoutSummary, tcx):
+    actual = tcx[0][0][2][8][0][3].text 
+    expected = "{0:.0f}".format(workoutSummary["avg_resistance"])
+    assert actual == expected
+
+def assertTcxMaxResistanceMatches(workoutSummary, tcx):
+    actual = tcx[0][0][2][8][0][4].text 
+    expected = "{0:.0f}".format(workoutSummary["max_resistance"])
+    assert actual == expected
+
+def assertTcxIntensityMatches(workoutSummary, tcx):
+    actual = tcx[0][0][2][6].text 
+    expected = "Active"
+    assert actual == expected
+
+def assertTcxTriggerMethodMatches(workoutSummary, tcx):
+    actual = tcx[0][0][2][7].text 
+    expected = "Manual"
     assert actual == expected

--- a/tests/test_tcx_builder.py
+++ b/tests/test_tcx_builder.py
@@ -43,15 +43,27 @@ class TestTcxBuilder:
         tcx = self.loadOutputTCX(os.path.join(output_directory, filename))
         TCX.assertTcxSportMatches("Biking", tcx)
         TCX.assertTcxIdMatches(workout_data, tcx)
+
         TCX.assertTcxLapStartTimeMatches(workout_data, tcx)
         TCX.assertTcxTotalTimeSecondsMatches(workout_data, tcx)
+        TCX.assertTcxTriggerMethodMatches(workout_summary, tcx)
+        TCX.assertTcxIntensityMatches(workout_summary, tcx)
+
+        TCX.assertTcxTotalPowerMatches(workout_summary, tcx)
         TCX.assertTcxMaximumSpeedMatches(workout_samples, tcx)
         TCX.assertTcxCaloriesMatches(workout_summary, tcx)
+
         TCX.assertTcxAvgHeartRateMatches(workout_summary,tcx)
-        TCX.assertTcxAvgSpeedMatches(workout_samples, tcx)
+        TCX.assertTcxMaxHeartRateMatches(workout_summary, tcx)
+
         TCX.assertTcxMaxBikeCadenceMatches(workout_summary, tcx)
+        TCX.assertTcxAvgBikeCadenceMatches(workout_summary, tcx)
+
         TCX.assertTcxAvgWattsMatches(workout_summary, tcx)
         TCX.assertTcxMaxWattsMatches(workout_summary, tcx)
+
+        TCX.assertTcxAvgResistanceMatches(workout_summary, tcx)
+        TCX.assertTcxMaxResistanceMatches(workout_summary, tcx)
 
     def test_cycling_km_smoketest(self):
         # Setup
@@ -72,15 +84,27 @@ class TestTcxBuilder:
         tcx = self.loadOutputTCX(os.path.join(output_directory, filename))
         TCX.assertTcxSportMatches("Biking", tcx)
         TCX.assertTcxIdMatches(workout_data, tcx)
+
         TCX.assertTcxLapStartTimeMatches(workout_data, tcx)
         TCX.assertTcxTotalTimeSecondsMatches(workout_data, tcx)
+        TCX.assertTcxTriggerMethodMatches(workout_summary, tcx)
+        TCX.assertTcxIntensityMatches(workout_summary, tcx)
+
+        TCX.assertTcxTotalPowerMatches(workout_summary, tcx)
         TCX.assertTcxMaximumSpeedMatches(workout_samples, tcx)
         TCX.assertTcxCaloriesMatches(workout_summary, tcx)
+
         TCX.assertTcxAvgHeartRateMatches(workout_summary,tcx)
-        TCX.assertTcxAvgSpeedMatches(workout_samples, tcx)
+        TCX.assertTcxMaxHeartRateMatches(workout_summary, tcx)
+
         TCX.assertTcxMaxBikeCadenceMatches(workout_summary, tcx)
+        TCX.assertTcxAvgBikeCadenceMatches(workout_summary, tcx)
+
         TCX.assertTcxAvgWattsMatches(workout_summary, tcx)
         TCX.assertTcxMaxWattsMatches(workout_summary, tcx)
+
+        TCX.assertTcxAvgResistanceMatches(workout_summary, tcx)
+        TCX.assertTcxMaxResistanceMatches(workout_summary, tcx)
 
     def test_cycling_freestyle_smoketest(self):
         # Setup
@@ -101,15 +125,27 @@ class TestTcxBuilder:
         tcx = self.loadOutputTCX(os.path.join(output_directory, filename))
         TCX.assertTcxSportMatches("Biking", tcx)
         TCX.assertTcxIdMatches(workout_data, tcx)
+
         TCX.assertTcxLapStartTimeMatches(workout_data, tcx)
         TCX.assertTcxTotalTimeSecondsMatches(workout_data, tcx)
+        TCX.assertTcxTriggerMethodMatches(workout_summary, tcx)
+        TCX.assertTcxIntensityMatches(workout_summary, tcx)
+
+        TCX.assertTcxTotalPowerMatches(workout_summary, tcx)
         TCX.assertTcxMaximumSpeedMatches(workout_samples, tcx)
         TCX.assertTcxCaloriesMatches(workout_summary, tcx)
+
         TCX.assertTcxAvgHeartRateMatches(workout_summary,tcx)
-        TCX.assertTcxAvgSpeedMatches(workout_samples, tcx)
+        TCX.assertTcxMaxHeartRateMatches(workout_summary, tcx)
+
         TCX.assertTcxMaxBikeCadenceMatches(workout_summary, tcx)
+        TCX.assertTcxAvgBikeCadenceMatches(workout_summary, tcx)
+
         TCX.assertTcxAvgWattsMatches(workout_summary, tcx)
         TCX.assertTcxMaxWattsMatches(workout_summary, tcx)
+
+        TCX.assertTcxAvgResistanceMatches(workout_summary, tcx)
+        TCX.assertTcxMaxResistanceMatches(workout_summary, tcx)
 
 
     def test_strength_smoketest(self):
@@ -136,7 +172,6 @@ class TestTcxBuilder:
         TCX.assertTcxMaximumSpeedMatches(workout_samples, tcx)
         TCX.assertTcxCaloriesMatches(workout_summary, tcx)
         TCX.assertTcxAvgHeartRateMatches(workout_summary,tcx)
-        TCX.assertTcxAvgSpeedMatches(workout_samples, tcx)
         TCX.assertTcxMaxBikeCadenceMatches(workout_summary, tcx)
         TCX.assertTcxAvgWattsMatches(workout_summary, tcx)
         TCX.assertTcxMaxWattsMatches(workout_summary, tcx)
@@ -166,7 +201,6 @@ class TestTcxBuilder:
         TCX.assertTcxMaximumSpeedMatches(workout_samples, tcx)
         TCX.assertTcxCaloriesMatches(workout_summary, tcx)
         TCX.assertTcxAvgHeartRateMatches(workout_summary,tcx)
-        TCX.assertTcxAvgSpeedMatches(workout_samples, tcx)
         TCX.assertTcxMaxBikeCadenceMatches(workout_summary, tcx)
         TCX.assertTcxAvgWattsMatches(workout_summary, tcx)
         TCX.assertTcxMaxWattsMatches(workout_summary, tcx)
@@ -196,7 +230,6 @@ class TestTcxBuilder:
         TCX.assertTcxMaximumSpeedMatches(workout_samples, tcx)
         TCX.assertTcxCaloriesMatches(workout_summary, tcx)
         TCX.assertTcxAvgHeartRateMatches(workout_summary,tcx)
-        TCX.assertTcxAvgSpeedMatches(workout_samples, tcx)
         TCX.assertTcxMaxBikeCadenceMatches(workout_summary, tcx)
         TCX.assertTcxAvgWattsMatches(workout_summary, tcx)
         TCX.assertTcxMaxWattsMatches(workout_summary, tcx)


### PR DESCRIPTION
#41 

Need to polish and fix unit tests, but I think this will resolve some of the occasional data discrepancy between peloton and garmin connect.

Previously, the script was not explicitly setting some of the summary data, which believe meant Garmin would calculate it from the raw data.  Its possible this could yield some differences between the summary data shown on peloton vs garmin.  Now, the script explicitly sets some additional summary fields in the tcx.