### PR TITLE
Add support for GPS data from outdoor activities - #35

### DIFF
--- a/lib/tcx_builder.py
+++ b/lib/tcx_builder.py
@@ -288,7 +288,11 @@ def workoutSamplesToTCX(workout, workoutSummary, workoutSamples, outputDir):
                 tposLon.text = str(locationData[index]["longitude"])
                 
                 tposAltitude = etree.Element("AltitudeMeters")
-                tposAltitude.text = str(convertFeetValueToMeters(altitudeData["values"][index]))
+                if(altitudeData["display_unit"] == "ft"):
+                    tposAltitude.text = str(convertFeetValueToMeters(altitudeData["values"][index]))
+                else:
+                    tposAltitude.text = str(altitudeData["values"][index])
+
                 trackPosition.append(tposLat)
                 trackPosition.append(tposLon)
                 trackPosition.append(tposAltitude)

--- a/tests/data/peloton_workoutsamples_running_outdoor.json
+++ b/tests/data/peloton_workoutsamples_running_outdoor.json
@@ -4832,6 +4832,9611 @@
         }
     ],
     "has_apple_watch_metrics": false,
+    "location_data": [
+        {
+            "segment_id": "867f3a0a9db045d0a066f2cc45c43598",
+            "is_gap": false,
+            "coordinates": [
+                {
+                    "accuracy": 100.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66731, 
+                    "longitude": 26.906616, 
+                    "seconds_offset_from_start": 1
+                }, 
+                {
+                    "accuracy": 90.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66935, 
+                    "longitude": 26.907267, 
+                    "seconds_offset_from_start": 2
+                }, 
+                {
+                    "accuracy": 95.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669638, 
+                    "longitude": 26.908034, 
+                    "seconds_offset_from_start": 3
+                }, 
+                {
+                    "accuracy": 99.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669249, 
+                    "longitude": 26.910516, 
+                    "seconds_offset_from_start": 4
+                }, 
+                {
+                    "accuracy": 63.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660712, 
+                    "longitude": 26.910286, 
+                    "seconds_offset_from_start": 5
+                }, 
+                {
+                    "accuracy": 81.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66004, 
+                    "longitude": 26.905223, 
+                    "seconds_offset_from_start": 6
+                }, 
+                {
+                    "accuracy": 62.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669617, 
+                    "longitude": 26.912262, 
+                    "seconds_offset_from_start": 7
+                }, 
+                {
+                    "accuracy": 73.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.6627, 
+                    "longitude": 26.910363, 
+                    "seconds_offset_from_start": 8
+                }, 
+                {
+                    "accuracy": 93.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666891, 
+                    "longitude": 26.90449, 
+                    "seconds_offset_from_start": 9
+                }, 
+                {
+                    "accuracy": 95.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668963, 
+                    "longitude": 26.909619, 
+                    "seconds_offset_from_start": 10
+                }, 
+                {
+                    "accuracy": 68.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66784, 
+                    "longitude": 26.90912, 
+                    "seconds_offset_from_start": 11
+                }, 
+                {
+                    "accuracy": 68.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667243, 
+                    "longitude": 26.905839, 
+                    "seconds_offset_from_start": 12
+                }, 
+                {
+                    "accuracy": 74.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667778, 
+                    "longitude": 26.904768, 
+                    "seconds_offset_from_start": 13
+                }, 
+                {
+                    "accuracy": 99.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660759, 
+                    "longitude": 26.908738, 
+                    "seconds_offset_from_start": 14
+                }, 
+                {
+                    "accuracy": 97.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664028, 
+                    "longitude": 26.908244, 
+                    "seconds_offset_from_start": 15
+                }, 
+                {
+                    "accuracy": 65.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663094, 
+                    "longitude": 26.907282, 
+                    "seconds_offset_from_start": 16
+                }, 
+                {
+                    "accuracy": 78.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669747, 
+                    "longitude": 26.904657, 
+                    "seconds_offset_from_start": 17
+                }, 
+                {
+                    "accuracy": 100.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663475, 
+                    "longitude": 26.911314, 
+                    "seconds_offset_from_start": 18
+                }, 
+                {
+                    "accuracy": 87.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668649, 
+                    "longitude": 26.911538, 
+                    "seconds_offset_from_start": 19
+                }, 
+                {
+                    "accuracy": 90.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669118, 
+                    "longitude": 26.909696, 
+                    "seconds_offset_from_start": 20
+                }, 
+                {
+                    "accuracy": 98.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660551, 
+                    "longitude": 26.910853, 
+                    "seconds_offset_from_start": 21
+                }, 
+                {
+                    "accuracy": 60.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665154, 
+                    "longitude": 26.908888, 
+                    "seconds_offset_from_start": 22
+                }, 
+                {
+                    "accuracy": 97.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660778, 
+                    "longitude": 26.91021, 
+                    "seconds_offset_from_start": 23
+                }, 
+                {
+                    "accuracy": 92.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665901, 
+                    "longitude": 26.90829, 
+                    "seconds_offset_from_start": 24
+                }, 
+                {
+                    "accuracy": 74.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665594, 
+                    "longitude": 26.905517, 
+                    "seconds_offset_from_start": 25
+                }, 
+                {
+                    "accuracy": 68.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665426, 
+                    "longitude": 26.910985, 
+                    "seconds_offset_from_start": 26
+                }, 
+                {
+                    "accuracy": 74.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660587, 
+                    "longitude": 26.906685, 
+                    "seconds_offset_from_start": 27
+                }, 
+                {
+                    "accuracy": 62.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662813, 
+                    "longitude": 26.909064, 
+                    "seconds_offset_from_start": 28
+                }, 
+                {
+                    "accuracy": 65.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660316, 
+                    "longitude": 26.911549, 
+                    "seconds_offset_from_start": 29
+                }, 
+                {
+                    "accuracy": 80.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66129, 
+                    "longitude": 26.909355, 
+                    "seconds_offset_from_start": 30
+                }, 
+                {
+                    "accuracy": 91.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661059, 
+                    "longitude": 26.910383, 
+                    "seconds_offset_from_start": 31
+                }, 
+                {
+                    "accuracy": 98.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665505, 
+                    "longitude": 26.906723, 
+                    "seconds_offset_from_start": 32
+                }, 
+                {
+                    "accuracy": 62.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664368, 
+                    "longitude": 26.908072, 
+                    "seconds_offset_from_start": 33
+                }, 
+                {
+                    "accuracy": 98.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669004, 
+                    "longitude": 26.909494, 
+                    "seconds_offset_from_start": 34
+                }, 
+                {
+                    "accuracy": 80.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66805, 
+                    "longitude": 26.910885, 
+                    "seconds_offset_from_start": 35
+                }, 
+                {
+                    "accuracy": 66.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669397, 
+                    "longitude": 26.907763, 
+                    "seconds_offset_from_start": 36
+                }, 
+                {
+                    "accuracy": 85.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661046, 
+                    "longitude": 26.905654, 
+                    "seconds_offset_from_start": 37
+                }, 
+                {
+                    "accuracy": 96.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661761, 
+                    "longitude": 26.90897, 
+                    "seconds_offset_from_start": 38
+                }, 
+                {
+                    "accuracy": 88.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668869, 
+                    "longitude": 26.907089, 
+                    "seconds_offset_from_start": 39
+                }, 
+                {
+                    "accuracy": 73.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662056, 
+                    "longitude": 26.907423, 
+                    "seconds_offset_from_start": 40
+                }, 
+                {
+                    "accuracy": 69.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664968, 
+                    "longitude": 26.909613, 
+                    "seconds_offset_from_start": 41
+                }, 
+                {
+                    "accuracy": 69.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660661, 
+                    "longitude": 26.911769, 
+                    "seconds_offset_from_start": 42
+                }, 
+                {
+                    "accuracy": 74.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665712, 
+                    "longitude": 26.907266, 
+                    "seconds_offset_from_start": 43
+                }, 
+                {
+                    "accuracy": 86.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668152, 
+                    "longitude": 26.903633, 
+                    "seconds_offset_from_start": 44
+                }, 
+                {
+                    "accuracy": 68.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661605, 
+                    "longitude": 26.91211, 
+                    "seconds_offset_from_start": 45
+                }, 
+                {
+                    "accuracy": 94.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66942, 
+                    "longitude": 26.907848, 
+                    "seconds_offset_from_start": 46
+                }, 
+                {
+                    "accuracy": 90.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660942, 
+                    "longitude": 26.903356, 
+                    "seconds_offset_from_start": 47
+                }, 
+                {
+                    "accuracy": 82.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66894, 
+                    "longitude": 26.904937, 
+                    "seconds_offset_from_start": 48
+                }, 
+                {
+                    "accuracy": 85.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664383, 
+                    "longitude": 26.904199, 
+                    "seconds_offset_from_start": 49
+                }, 
+                {
+                    "accuracy": 74.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666369, 
+                    "longitude": 26.904735, 
+                    "seconds_offset_from_start": 50
+                }, 
+                {
+                    "accuracy": 74.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668235, 
+                    "longitude": 26.90278, 
+                    "seconds_offset_from_start": 51
+                }, 
+                {
+                    "accuracy": 96.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668741, 
+                    "longitude": 26.906696, 
+                    "seconds_offset_from_start": 52
+                }, 
+                {
+                    "accuracy": 93.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664321, 
+                    "longitude": 26.911152, 
+                    "seconds_offset_from_start": 53
+                }, 
+                {
+                    "accuracy": 66.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660488, 
+                    "longitude": 26.910941, 
+                    "seconds_offset_from_start": 54
+                }, 
+                {
+                    "accuracy": 87.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663525, 
+                    "longitude": 26.905176, 
+                    "seconds_offset_from_start": 55
+                }, 
+                {
+                    "accuracy": 89.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668075, 
+                    "longitude": 26.911057, 
+                    "seconds_offset_from_start": 56
+                }, 
+                {
+                    "accuracy": 84.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666656, 
+                    "longitude": 26.90872, 
+                    "seconds_offset_from_start": 57
+                }, 
+                {
+                    "accuracy": 76.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664278, 
+                    "longitude": 26.908361, 
+                    "seconds_offset_from_start": 58
+                }, 
+                {
+                    "accuracy": 63.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663401, 
+                    "longitude": 26.902565, 
+                    "seconds_offset_from_start": 59
+                }
+            ]
+        },
+        {
+            "segment_id": "0a1e3b75546c456dbffad5f5a8b7d5b9",
+            "is_gap": false,
+            "coordinates": [
+                {
+                    "accuracy": 67.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666185, 
+                    "longitude": 26.911859, 
+                    "seconds_offset_from_start": 60
+                }, 
+                {
+                    "accuracy": 62.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669341, 
+                    "longitude": 26.903695, 
+                    "seconds_offset_from_start": 61
+                }, 
+                {
+                    "accuracy": 67.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66288, 
+                    "longitude": 26.910309, 
+                    "seconds_offset_from_start": 62
+                }, 
+                {
+                    "accuracy": 90.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661324, 
+                    "longitude": 26.90731, 
+                    "seconds_offset_from_start": 63
+                }, 
+                {
+                    "accuracy": 61.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665709, 
+                    "longitude": 26.91124, 
+                    "seconds_offset_from_start": 64
+                }, 
+                {
+                    "accuracy": 80.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663947, 
+                    "longitude": 26.90347, 
+                    "seconds_offset_from_start": 65
+                }, 
+                {
+                    "accuracy": 88.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661799, 
+                    "longitude": 26.903736, 
+                    "seconds_offset_from_start": 66
+                }, 
+                {
+                    "accuracy": 76.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661851, 
+                    "longitude": 26.9056, 
+                    "seconds_offset_from_start": 67
+                }, 
+                {
+                    "accuracy": 78.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660093, 
+                    "longitude": 26.903896, 
+                    "seconds_offset_from_start": 68
+                }, 
+                {
+                    "accuracy": 97.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664475, 
+                    "longitude": 26.910908, 
+                    "seconds_offset_from_start": 69
+                }, 
+                {
+                    "accuracy": 68.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668718, 
+                    "longitude": 26.903539, 
+                    "seconds_offset_from_start": 70
+                }, 
+                {
+                    "accuracy": 81.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668225, 
+                    "longitude": 26.910369, 
+                    "seconds_offset_from_start": 71
+                }, 
+                {
+                    "accuracy": 96.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660959, 
+                    "longitude": 26.902506, 
+                    "seconds_offset_from_start": 72
+                }, 
+                {
+                    "accuracy": 96.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668569, 
+                    "longitude": 26.906695, 
+                    "seconds_offset_from_start": 73
+                }, 
+                {
+                    "accuracy": 88.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660728, 
+                    "longitude": 26.90999, 
+                    "seconds_offset_from_start": 74
+                }, 
+                {
+                    "accuracy": 82.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669748, 
+                    "longitude": 26.906385, 
+                    "seconds_offset_from_start": 75
+                }, 
+                {
+                    "accuracy": 75.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661163, 
+                    "longitude": 26.90932, 
+                    "seconds_offset_from_start": 76
+                }, 
+                {
+                    "accuracy": 61.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668316, 
+                    "longitude": 26.903779, 
+                    "seconds_offset_from_start": 77
+                }, 
+                {
+                    "accuracy": 63.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662312, 
+                    "longitude": 26.905221, 
+                    "seconds_offset_from_start": 78
+                }, 
+                {
+                    "accuracy": 94.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668273, 
+                    "longitude": 26.903713, 
+                    "seconds_offset_from_start": 79
+                }, 
+                {
+                    "accuracy": 71.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664332, 
+                    "longitude": 26.904831, 
+                    "seconds_offset_from_start": 80
+                }, 
+                {
+                    "accuracy": 93.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663506, 
+                    "longitude": 26.904523, 
+                    "seconds_offset_from_start": 81
+                }, 
+                {
+                    "accuracy": 99.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660837, 
+                    "longitude": 26.906523, 
+                    "seconds_offset_from_start": 82
+                }, 
+                {
+                    "accuracy": 65.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669892, 
+                    "longitude": 26.906616, 
+                    "seconds_offset_from_start": 83
+                }, 
+                {
+                    "accuracy": 78.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663985, 
+                    "longitude": 26.909087, 
+                    "seconds_offset_from_start": 84
+                }, 
+                {
+                    "accuracy": 78.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666337, 
+                    "longitude": 26.911788, 
+                    "seconds_offset_from_start": 85
+                }, 
+                {
+                    "accuracy": 92.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66464, 
+                    "longitude": 26.911618, 
+                    "seconds_offset_from_start": 86
+                }, 
+                {
+                    "accuracy": 89.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663198, 
+                    "longitude": 26.906555, 
+                    "seconds_offset_from_start": 87
+                }, 
+                {
+                    "accuracy": 79.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668375, 
+                    "longitude": 26.9039, 
+                    "seconds_offset_from_start": 88
+                }, 
+                {
+                    "accuracy": 65.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66687, 
+                    "longitude": 26.909874, 
+                    "seconds_offset_from_start": 89
+                }, 
+                {
+                    "accuracy": 95.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667789, 
+                    "longitude": 26.903627, 
+                    "seconds_offset_from_start": 90
+                }, 
+                {
+                    "accuracy": 93.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668727, 
+                    "longitude": 26.912271, 
+                    "seconds_offset_from_start": 91
+                }, 
+                {
+                    "accuracy": 74.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669428, 
+                    "longitude": 26.902931, 
+                    "seconds_offset_from_start": 92
+                }, 
+                {
+                    "accuracy": 68.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666068, 
+                    "longitude": 26.903391, 
+                    "seconds_offset_from_start": 93
+                }, 
+                {
+                    "accuracy": 68.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669247, 
+                    "longitude": 26.908159, 
+                    "seconds_offset_from_start": 94
+                }, 
+                {
+                    "accuracy": 94.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662174, 
+                    "longitude": 26.910099, 
+                    "seconds_offset_from_start": 95
+                }, 
+                {
+                    "accuracy": 63.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664915, 
+                    "longitude": 26.904613, 
+                    "seconds_offset_from_start": 96
+                }, 
+                {
+                    "accuracy": 76.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665131, 
+                    "longitude": 26.910687, 
+                    "seconds_offset_from_start": 97
+                }, 
+                {
+                    "accuracy": 67.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.6619, 
+                    "longitude": 26.905974, 
+                    "seconds_offset_from_start": 98
+                }, 
+                {
+                    "accuracy": 88.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667654, 
+                    "longitude": 26.909745, 
+                    "seconds_offset_from_start": 99
+                }, 
+                {
+                    "accuracy": 74.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660963, 
+                    "longitude": 26.909778, 
+                    "seconds_offset_from_start": 100
+                }, 
+                {
+                    "accuracy": 81.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668839, 
+                    "longitude": 26.911926, 
+                    "seconds_offset_from_start": 101
+                }, 
+                {
+                    "accuracy": 61.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663277, 
+                    "longitude": 26.908645, 
+                    "seconds_offset_from_start": 102
+                }, 
+                {
+                    "accuracy": 84.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660683, 
+                    "longitude": 26.90593, 
+                    "seconds_offset_from_start": 103
+                }, 
+                {
+                    "accuracy": 93.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664179, 
+                    "longitude": 26.904035, 
+                    "seconds_offset_from_start": 104
+                }, 
+                {
+                    "accuracy": 78.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669159, 
+                    "longitude": 26.908285, 
+                    "seconds_offset_from_start": 105
+                }, 
+                {
+                    "accuracy": 91.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669563, 
+                    "longitude": 26.908081, 
+                    "seconds_offset_from_start": 106
+                }, 
+                {
+                    "accuracy": 93.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665228, 
+                    "longitude": 26.908877, 
+                    "seconds_offset_from_start": 107
+                }, 
+                {
+                    "accuracy": 73.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.6654, 
+                    "longitude": 26.903017, 
+                    "seconds_offset_from_start": 108
+                }, 
+                {
+                    "accuracy": 85.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661855, 
+                    "longitude": 26.911983, 
+                    "seconds_offset_from_start": 109
+                }, 
+                {
+                    "accuracy": 80.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660365, 
+                    "longitude": 26.908619, 
+                    "seconds_offset_from_start": 110
+                }, 
+                {
+                    "accuracy": 84.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661173, 
+                    "longitude": 26.903921, 
+                    "seconds_offset_from_start": 111
+                }, 
+                {
+                    "accuracy": 89.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664953, 
+                    "longitude": 26.910456, 
+                    "seconds_offset_from_start": 112
+                }, 
+                {
+                    "accuracy": 83.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663592, 
+                    "longitude": 26.910699, 
+                    "seconds_offset_from_start": 113
+                }, 
+                {
+                    "accuracy": 97.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668006, 
+                    "longitude": 26.910784, 
+                    "seconds_offset_from_start": 114
+                }, 
+                {
+                    "accuracy": 60.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668876, 
+                    "longitude": 26.909154, 
+                    "seconds_offset_from_start": 115
+                }, 
+                {
+                    "accuracy": 70.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661638, 
+                    "longitude": 26.907813, 
+                    "seconds_offset_from_start": 116
+                }, 
+                {
+                    "accuracy": 79.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661781, 
+                    "longitude": 26.903179, 
+                    "seconds_offset_from_start": 117
+                }, 
+                {
+                    "accuracy": 96.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667972, 
+                    "longitude": 26.912351, 
+                    "seconds_offset_from_start": 118
+                }, 
+                {
+                    "accuracy": 95.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661086, 
+                    "longitude": 26.906941, 
+                    "seconds_offset_from_start": 119
+                }, 
+                {
+                    "accuracy": 86.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669661, 
+                    "longitude": 26.90595, 
+                    "seconds_offset_from_start": 120
+                }, 
+                {
+                    "accuracy": 79.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662658, 
+                    "longitude": 26.906105, 
+                    "seconds_offset_from_start": 121
+                }, 
+                {
+                    "accuracy": 76.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669984, 
+                    "longitude": 26.90824, 
+                    "seconds_offset_from_start": 122
+                }, 
+                {
+                    "accuracy": 80.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666544, 
+                    "longitude": 26.904282, 
+                    "seconds_offset_from_start": 123
+                }, 
+                {
+                    "accuracy": 87.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662437, 
+                    "longitude": 26.906717, 
+                    "seconds_offset_from_start": 124
+                }, 
+                {
+                    "accuracy": 86.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661619, 
+                    "longitude": 26.908849, 
+                    "seconds_offset_from_start": 125
+                }, 
+                {
+                    "accuracy": 78.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660128, 
+                    "longitude": 26.909034, 
+                    "seconds_offset_from_start": 126
+                }, 
+                {
+                    "accuracy": 93.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667694, 
+                    "longitude": 26.904912, 
+                    "seconds_offset_from_start": 127
+                }, 
+                {
+                    "accuracy": 60.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667235, 
+                    "longitude": 26.910768, 
+                    "seconds_offset_from_start": 128
+                }, 
+                {
+                    "accuracy": 64.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660088, 
+                    "longitude": 26.904179, 
+                    "seconds_offset_from_start": 129
+                }, 
+                {
+                    "accuracy": 94.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668264, 
+                    "longitude": 26.90575, 
+                    "seconds_offset_from_start": 130
+                }, 
+                {
+                    "accuracy": 81.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661453, 
+                    "longitude": 26.9115, 
+                    "seconds_offset_from_start": 131
+                }, 
+                {
+                    "accuracy": 74.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668027, 
+                    "longitude": 26.903313, 
+                    "seconds_offset_from_start": 132
+                }, 
+                {
+                    "accuracy": 61.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667392, 
+                    "longitude": 26.906687, 
+                    "seconds_offset_from_start": 133
+                }, 
+                {
+                    "accuracy": 97.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666712, 
+                    "longitude": 26.905085, 
+                    "seconds_offset_from_start": 134
+                }, 
+                {
+                    "accuracy": 85.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667187, 
+                    "longitude": 26.911239, 
+                    "seconds_offset_from_start": 135
+                }, 
+                {
+                    "accuracy": 90.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661127, 
+                    "longitude": 26.902536, 
+                    "seconds_offset_from_start": 136
+                }, 
+                {
+                    "accuracy": 67.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664217, 
+                    "longitude": 26.903181, 
+                    "seconds_offset_from_start": 137
+                }, 
+                {
+                    "accuracy": 98.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661135, 
+                    "longitude": 26.904323, 
+                    "seconds_offset_from_start": 138
+                }, 
+                {
+                    "accuracy": 90.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662071, 
+                    "longitude": 26.9093, 
+                    "seconds_offset_from_start": 139
+                }, 
+                {
+                    "accuracy": 77.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662539, 
+                    "longitude": 26.903403, 
+                    "seconds_offset_from_start": 140
+                }, 
+                {
+                    "accuracy": 100.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661655, 
+                    "longitude": 26.912038, 
+                    "seconds_offset_from_start": 141
+                }, 
+                {
+                    "accuracy": 69.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662306, 
+                    "longitude": 26.911036, 
+                    "seconds_offset_from_start": 142
+                }, 
+                {
+                    "accuracy": 86.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668893, 
+                    "longitude": 26.910416, 
+                    "seconds_offset_from_start": 143
+                }, 
+                {
+                    "accuracy": 100.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660617, 
+                    "longitude": 26.904933, 
+                    "seconds_offset_from_start": 144
+                }, 
+                {
+                    "accuracy": 97.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661383, 
+                    "longitude": 26.907426, 
+                    "seconds_offset_from_start": 145
+                }, 
+                {
+                    "accuracy": 67.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661928, 
+                    "longitude": 26.907523, 
+                    "seconds_offset_from_start": 146
+                }, 
+                {
+                    "accuracy": 85.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664948, 
+                    "longitude": 26.904465, 
+                    "seconds_offset_from_start": 147
+                }, 
+                {
+                    "accuracy": 75.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661393, 
+                    "longitude": 26.911429, 
+                    "seconds_offset_from_start": 148
+                }, 
+                {
+                    "accuracy": 100.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662404, 
+                    "longitude": 26.904835, 
+                    "seconds_offset_from_start": 149
+                }, 
+                {
+                    "accuracy": 96.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665589, 
+                    "longitude": 26.909355, 
+                    "seconds_offset_from_start": 150
+                }, 
+                {
+                    "accuracy": 67.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662352, 
+                    "longitude": 26.904383, 
+                    "seconds_offset_from_start": 151
+                }, 
+                {
+                    "accuracy": 85.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661025, 
+                    "longitude": 26.908572, 
+                    "seconds_offset_from_start": 152
+                }, 
+                {
+                    "accuracy": 63.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662719, 
+                    "longitude": 26.912214, 
+                    "seconds_offset_from_start": 153
+                }, 
+                {
+                    "accuracy": 86.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662035, 
+                    "longitude": 26.903508, 
+                    "seconds_offset_from_start": 154
+                }, 
+                {
+                    "accuracy": 93.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66521, 
+                    "longitude": 26.904163, 
+                    "seconds_offset_from_start": 155
+                }, 
+                {
+                    "accuracy": 67.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667745, 
+                    "longitude": 26.904192, 
+                    "seconds_offset_from_start": 156
+                }, 
+                {
+                    "accuracy": 76.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669539, 
+                    "longitude": 26.908423, 
+                    "seconds_offset_from_start": 157
+                }, 
+                {
+                    "accuracy": 95.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662253, 
+                    "longitude": 26.908277, 
+                    "seconds_offset_from_start": 158
+                }, 
+                {
+                    "accuracy": 97.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663136, 
+                    "longitude": 26.907872, 
+                    "seconds_offset_from_start": 159
+                }, 
+                {
+                    "accuracy": 75.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661586, 
+                    "longitude": 26.90796, 
+                    "seconds_offset_from_start": 160
+                }, 
+                {
+                    "accuracy": 89.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669051, 
+                    "longitude": 26.906467, 
+                    "seconds_offset_from_start": 161
+                }, 
+                {
+                    "accuracy": 95.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66225, 
+                    "longitude": 26.908991, 
+                    "seconds_offset_from_start": 162
+                }, 
+                {
+                    "accuracy": 92.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660387, 
+                    "longitude": 26.905152, 
+                    "seconds_offset_from_start": 163
+                }, 
+                {
+                    "accuracy": 78.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660849, 
+                    "longitude": 26.902692, 
+                    "seconds_offset_from_start": 164
+                }, 
+                {
+                    "accuracy": 63.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668997, 
+                    "longitude": 26.908676, 
+                    "seconds_offset_from_start": 165
+                }, 
+                {
+                    "accuracy": 83.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667702, 
+                    "longitude": 26.911199, 
+                    "seconds_offset_from_start": 166
+                }, 
+                {
+                    "accuracy": 83.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66315, 
+                    "longitude": 26.905768, 
+                    "seconds_offset_from_start": 167
+                }, 
+                {
+                    "accuracy": 87.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669308, 
+                    "longitude": 26.911184, 
+                    "seconds_offset_from_start": 168
+                }, 
+                {
+                    "accuracy": 100.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663735, 
+                    "longitude": 26.905284, 
+                    "seconds_offset_from_start": 169
+                }, 
+                {
+                    "accuracy": 76.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666695, 
+                    "longitude": 26.910388, 
+                    "seconds_offset_from_start": 170
+                }, 
+                {
+                    "accuracy": 69.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668996, 
+                    "longitude": 26.904626, 
+                    "seconds_offset_from_start": 171
+                }, 
+                {
+                    "accuracy": 100.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661256, 
+                    "longitude": 26.904942, 
+                    "seconds_offset_from_start": 172
+                }, 
+                {
+                    "accuracy": 89.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669052, 
+                    "longitude": 26.910335, 
+                    "seconds_offset_from_start": 173
+                }, 
+                {
+                    "accuracy": 87.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664864, 
+                    "longitude": 26.90814, 
+                    "seconds_offset_from_start": 174
+                }, 
+                {
+                    "accuracy": 92.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669308, 
+                    "longitude": 26.904395, 
+                    "seconds_offset_from_start": 175
+                }, 
+                {
+                    "accuracy": 93.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662522, 
+                    "longitude": 26.909728, 
+                    "seconds_offset_from_start": 176
+                }, 
+                {
+                    "accuracy": 61.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662738, 
+                    "longitude": 26.909562, 
+                    "seconds_offset_from_start": 177
+                }, 
+                {
+                    "accuracy": 68.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668561, 
+                    "longitude": 26.910047, 
+                    "seconds_offset_from_start": 178
+                }, 
+                {
+                    "accuracy": 78.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665478, 
+                    "longitude": 26.903429, 
+                    "seconds_offset_from_start": 179
+                }, 
+                {
+                    "accuracy": 69.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66006, 
+                    "longitude": 26.908748, 
+                    "seconds_offset_from_start": 180
+                }, 
+                {
+                    "accuracy": 60.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662854, 
+                    "longitude": 26.904601, 
+                    "seconds_offset_from_start": 181
+                }, 
+                {
+                    "accuracy": 88.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663155, 
+                    "longitude": 26.910088, 
+                    "seconds_offset_from_start": 182
+                }, 
+                {
+                    "accuracy": 88.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662614, 
+                    "longitude": 26.9108, 
+                    "seconds_offset_from_start": 183
+                }, 
+                {
+                    "accuracy": 97.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666445, 
+                    "longitude": 26.905584, 
+                    "seconds_offset_from_start": 184
+                }, 
+                {
+                    "accuracy": 84.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665638, 
+                    "longitude": 26.907186, 
+                    "seconds_offset_from_start": 185
+                }, 
+                {
+                    "accuracy": 69.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662302, 
+                    "longitude": 26.906987, 
+                    "seconds_offset_from_start": 186
+                }, 
+                {
+                    "accuracy": 73.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662284, 
+                    "longitude": 26.902599, 
+                    "seconds_offset_from_start": 187
+                }, 
+                {
+                    "accuracy": 96.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667548, 
+                    "longitude": 26.90675, 
+                    "seconds_offset_from_start": 188
+                }, 
+                {
+                    "accuracy": 71.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665402, 
+                    "longitude": 26.906272, 
+                    "seconds_offset_from_start": 189
+                }, 
+                {
+                    "accuracy": 81.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668676, 
+                    "longitude": 26.904838, 
+                    "seconds_offset_from_start": 190
+                }, 
+                {
+                    "accuracy": 75.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665205, 
+                    "longitude": 26.912483, 
+                    "seconds_offset_from_start": 191
+                }, 
+                {
+                    "accuracy": 60.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661338, 
+                    "longitude": 26.908021, 
+                    "seconds_offset_from_start": 192
+                }, 
+                {
+                    "accuracy": 82.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66257, 
+                    "longitude": 26.906222, 
+                    "seconds_offset_from_start": 193
+                }, 
+                {
+                    "accuracy": 73.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665795, 
+                    "longitude": 26.907613, 
+                    "seconds_offset_from_start": 194
+                }, 
+                {
+                    "accuracy": 69.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660688, 
+                    "longitude": 26.911332, 
+                    "seconds_offset_from_start": 195
+                }, 
+                {
+                    "accuracy": 79.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666271, 
+                    "longitude": 26.906955, 
+                    "seconds_offset_from_start": 196
+                }, 
+                {
+                    "accuracy": 80.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668791, 
+                    "longitude": 26.910553, 
+                    "seconds_offset_from_start": 197
+                }, 
+                {
+                    "accuracy": 70.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668063, 
+                    "longitude": 26.906607, 
+                    "seconds_offset_from_start": 198
+                }, 
+                {
+                    "accuracy": 86.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667102, 
+                    "longitude": 26.905516, 
+                    "seconds_offset_from_start": 199
+                }, 
+                {
+                    "accuracy": 79.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666978, 
+                    "longitude": 26.908052, 
+                    "seconds_offset_from_start": 200
+                }, 
+                {
+                    "accuracy": 91.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668569, 
+                    "longitude": 26.904087, 
+                    "seconds_offset_from_start": 201
+                }, 
+                {
+                    "accuracy": 88.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662653, 
+                    "longitude": 26.908395, 
+                    "seconds_offset_from_start": 202
+                }, 
+                {
+                    "accuracy": 63.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663586, 
+                    "longitude": 26.905495, 
+                    "seconds_offset_from_start": 203
+                }, 
+                {
+                    "accuracy": 71.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666735, 
+                    "longitude": 26.911051, 
+                    "seconds_offset_from_start": 204
+                }, 
+                {
+                    "accuracy": 80.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667991, 
+                    "longitude": 26.907588, 
+                    "seconds_offset_from_start": 205
+                }, 
+                {
+                    "accuracy": 69.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664502, 
+                    "longitude": 26.906071, 
+                    "seconds_offset_from_start": 206
+                }, 
+                {
+                    "accuracy": 72.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668993, 
+                    "longitude": 26.904237, 
+                    "seconds_offset_from_start": 207
+                }, 
+                {
+                    "accuracy": 73.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669449, 
+                    "longitude": 26.910901, 
+                    "seconds_offset_from_start": 208
+                }, 
+                {
+                    "accuracy": 91.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669484, 
+                    "longitude": 26.911792, 
+                    "seconds_offset_from_start": 209
+                }, 
+                {
+                    "accuracy": 90.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667907, 
+                    "longitude": 26.907383, 
+                    "seconds_offset_from_start": 210
+                }, 
+                {
+                    "accuracy": 82.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663085, 
+                    "longitude": 26.906614, 
+                    "seconds_offset_from_start": 211
+                }, 
+                {
+                    "accuracy": 75.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665095, 
+                    "longitude": 26.911916, 
+                    "seconds_offset_from_start": 212
+                }, 
+                {
+                    "accuracy": 80.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669985, 
+                    "longitude": 26.902683, 
+                    "seconds_offset_from_start": 213
+                }, 
+                {
+                    "accuracy": 64.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666973, 
+                    "longitude": 26.904761, 
+                    "seconds_offset_from_start": 214
+                }, 
+                {
+                    "accuracy": 61.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663326, 
+                    "longitude": 26.908568, 
+                    "seconds_offset_from_start": 215
+                }, 
+                {
+                    "accuracy": 68.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669174, 
+                    "longitude": 26.904265, 
+                    "seconds_offset_from_start": 216
+                }, 
+                {
+                    "accuracy": 61.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664705, 
+                    "longitude": 26.911421, 
+                    "seconds_offset_from_start": 217
+                }, 
+                {
+                    "accuracy": 81.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665102, 
+                    "longitude": 26.908252, 
+                    "seconds_offset_from_start": 218
+                }, 
+                {
+                    "accuracy": 79.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666237, 
+                    "longitude": 26.903744, 
+                    "seconds_offset_from_start": 219
+                }, 
+                {
+                    "accuracy": 93.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664963, 
+                    "longitude": 26.910739, 
+                    "seconds_offset_from_start": 220
+                }, 
+                {
+                    "accuracy": 96.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662795, 
+                    "longitude": 26.91099, 
+                    "seconds_offset_from_start": 221
+                }, 
+                {
+                    "accuracy": 72.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662563, 
+                    "longitude": 26.904161, 
+                    "seconds_offset_from_start": 222
+                }, 
+                {
+                    "accuracy": 69.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668963, 
+                    "longitude": 26.907956, 
+                    "seconds_offset_from_start": 223
+                }, 
+                {
+                    "accuracy": 96.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66188, 
+                    "longitude": 26.905611, 
+                    "seconds_offset_from_start": 224
+                }, 
+                {
+                    "accuracy": 75.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667101, 
+                    "longitude": 26.911388, 
+                    "seconds_offset_from_start": 225
+                }, 
+                {
+                    "accuracy": 95.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669395, 
+                    "longitude": 26.912341, 
+                    "seconds_offset_from_start": 226
+                }, 
+                {
+                    "accuracy": 82.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666955, 
+                    "longitude": 26.911281, 
+                    "seconds_offset_from_start": 227
+                }, 
+                {
+                    "accuracy": 91.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667981, 
+                    "longitude": 26.904194, 
+                    "seconds_offset_from_start": 228
+                }, 
+                {
+                    "accuracy": 68.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661233, 
+                    "longitude": 26.910373, 
+                    "seconds_offset_from_start": 229
+                }, 
+                {
+                    "accuracy": 63.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662406, 
+                    "longitude": 26.904106, 
+                    "seconds_offset_from_start": 230
+                }, 
+                {
+                    "accuracy": 88.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667613, 
+                    "longitude": 26.904555, 
+                    "seconds_offset_from_start": 231
+                }, 
+                {
+                    "accuracy": 67.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668232, 
+                    "longitude": 26.91193, 
+                    "seconds_offset_from_start": 232
+                }, 
+                {
+                    "accuracy": 87.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668748, 
+                    "longitude": 26.90561, 
+                    "seconds_offset_from_start": 233
+                }, 
+                {
+                    "accuracy": 61.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668946, 
+                    "longitude": 26.907035, 
+                    "seconds_offset_from_start": 234
+                }, 
+                {
+                    "accuracy": 81.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660446, 
+                    "longitude": 26.906203, 
+                    "seconds_offset_from_start": 235
+                }, 
+                {
+                    "accuracy": 81.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.6643, 
+                    "longitude": 26.909744, 
+                    "seconds_offset_from_start": 236
+                }, 
+                {
+                    "accuracy": 87.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662245, 
+                    "longitude": 26.909886, 
+                    "seconds_offset_from_start": 237
+                }, 
+                {
+                    "accuracy": 82.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666301, 
+                    "longitude": 26.905463, 
+                    "seconds_offset_from_start": 238
+                }, 
+                {
+                    "accuracy": 73.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669889, 
+                    "longitude": 26.904973, 
+                    "seconds_offset_from_start": 239
+                }, 
+                {
+                    "accuracy": 92.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662116, 
+                    "longitude": 26.904917, 
+                    "seconds_offset_from_start": 240
+                }, 
+                {
+                    "accuracy": 90.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667227, 
+                    "longitude": 26.905289, 
+                    "seconds_offset_from_start": 241
+                }, 
+                {
+                    "accuracy": 87.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661274, 
+                    "longitude": 26.907325, 
+                    "seconds_offset_from_start": 242
+                }, 
+                {
+                    "accuracy": 75.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663237, 
+                    "longitude": 26.910413, 
+                    "seconds_offset_from_start": 243
+                }, 
+                {
+                    "accuracy": 67.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661746, 
+                    "longitude": 26.905418, 
+                    "seconds_offset_from_start": 244
+                }, 
+                {
+                    "accuracy": 98.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661116, 
+                    "longitude": 26.903605, 
+                    "seconds_offset_from_start": 245
+                }, 
+                {
+                    "accuracy": 86.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667815, 
+                    "longitude": 26.906943, 
+                    "seconds_offset_from_start": 246
+                }, 
+                {
+                    "accuracy": 95.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665378, 
+                    "longitude": 26.905753, 
+                    "seconds_offset_from_start": 247
+                }, 
+                {
+                    "accuracy": 70.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665987, 
+                    "longitude": 26.911178, 
+                    "seconds_offset_from_start": 248
+                }, 
+                {
+                    "accuracy": 69.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660301, 
+                    "longitude": 26.903125, 
+                    "seconds_offset_from_start": 249
+                }, 
+                {
+                    "accuracy": 96.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665832, 
+                    "longitude": 26.902861, 
+                    "seconds_offset_from_start": 250
+                }, 
+                {
+                    "accuracy": 89.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663138, 
+                    "longitude": 26.904946, 
+                    "seconds_offset_from_start": 251
+                }, 
+                {
+                    "accuracy": 60.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66101, 
+                    "longitude": 26.904416, 
+                    "seconds_offset_from_start": 252
+                }, 
+                {
+                    "accuracy": 86.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666585, 
+                    "longitude": 26.912286, 
+                    "seconds_offset_from_start": 253
+                }, 
+                {
+                    "accuracy": 100.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66348, 
+                    "longitude": 26.905749, 
+                    "seconds_offset_from_start": 254
+                }, 
+                {
+                    "accuracy": 85.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666167, 
+                    "longitude": 26.911176, 
+                    "seconds_offset_from_start": 255
+                }, 
+                {
+                    "accuracy": 72.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66643, 
+                    "longitude": 26.90501, 
+                    "seconds_offset_from_start": 256
+                }, 
+                {
+                    "accuracy": 94.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667194, 
+                    "longitude": 26.90797, 
+                    "seconds_offset_from_start": 257
+                }, 
+                {
+                    "accuracy": 60.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661727, 
+                    "longitude": 26.909634, 
+                    "seconds_offset_from_start": 258
+                }, 
+                {
+                    "accuracy": 77.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666682, 
+                    "longitude": 26.906081, 
+                    "seconds_offset_from_start": 259
+                }, 
+                {
+                    "accuracy": 85.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668018, 
+                    "longitude": 26.903446, 
+                    "seconds_offset_from_start": 260
+                }, 
+                {
+                    "accuracy": 77.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669576, 
+                    "longitude": 26.909922, 
+                    "seconds_offset_from_start": 261
+                }, 
+                {
+                    "accuracy": 89.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666784, 
+                    "longitude": 26.907292, 
+                    "seconds_offset_from_start": 262
+                }, 
+                {
+                    "accuracy": 79.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665589, 
+                    "longitude": 26.905073, 
+                    "seconds_offset_from_start": 263
+                }, 
+                {
+                    "accuracy": 81.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665981, 
+                    "longitude": 26.907683, 
+                    "seconds_offset_from_start": 264
+                }, 
+                {
+                    "accuracy": 95.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664004, 
+                    "longitude": 26.906486, 
+                    "seconds_offset_from_start": 265
+                }, 
+                {
+                    "accuracy": 69.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66165, 
+                    "longitude": 26.909642, 
+                    "seconds_offset_from_start": 266
+                }, 
+                {
+                    "accuracy": 83.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664639, 
+                    "longitude": 26.911586, 
+                    "seconds_offset_from_start": 267
+                }, 
+                {
+                    "accuracy": 90.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666835, 
+                    "longitude": 26.910636, 
+                    "seconds_offset_from_start": 268
+                }, 
+                {
+                    "accuracy": 92.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666658, 
+                    "longitude": 26.907355, 
+                    "seconds_offset_from_start": 269
+                }, 
+                {
+                    "accuracy": 98.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661548, 
+                    "longitude": 26.905966, 
+                    "seconds_offset_from_start": 270
+                }, 
+                {
+                    "accuracy": 89.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660272, 
+                    "longitude": 26.907957, 
+                    "seconds_offset_from_start": 271
+                }, 
+                {
+                    "accuracy": 81.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666007, 
+                    "longitude": 26.909106, 
+                    "seconds_offset_from_start": 272
+                }, 
+                {
+                    "accuracy": 70.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660677, 
+                    "longitude": 26.911482, 
+                    "seconds_offset_from_start": 273
+                }, 
+                {
+                    "accuracy": 70.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669038, 
+                    "longitude": 26.909134, 
+                    "seconds_offset_from_start": 274
+                }, 
+                {
+                    "accuracy": 70.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668763, 
+                    "longitude": 26.912071, 
+                    "seconds_offset_from_start": 275
+                }, 
+                {
+                    "accuracy": 70.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661671, 
+                    "longitude": 26.910105, 
+                    "seconds_offset_from_start": 276
+                }, 
+                {
+                    "accuracy": 86.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66765, 
+                    "longitude": 26.905002, 
+                    "seconds_offset_from_start": 277
+                }, 
+                {
+                    "accuracy": 83.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669076, 
+                    "longitude": 26.90908, 
+                    "seconds_offset_from_start": 278
+                }, 
+                {
+                    "accuracy": 66.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669163, 
+                    "longitude": 26.908615, 
+                    "seconds_offset_from_start": 279
+                }, 
+                {
+                    "accuracy": 62.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667167, 
+                    "longitude": 26.904239, 
+                    "seconds_offset_from_start": 280
+                }, 
+                {
+                    "accuracy": 72.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665023, 
+                    "longitude": 26.90739, 
+                    "seconds_offset_from_start": 281
+                }, 
+                {
+                    "accuracy": 88.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66568, 
+                    "longitude": 26.906643, 
+                    "seconds_offset_from_start": 282
+                }, 
+                {
+                    "accuracy": 73.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663975, 
+                    "longitude": 26.911095, 
+                    "seconds_offset_from_start": 283
+                }, 
+                {
+                    "accuracy": 68.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666512, 
+                    "longitude": 26.90393, 
+                    "seconds_offset_from_start": 284
+                }, 
+                {
+                    "accuracy": 61.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662836, 
+                    "longitude": 26.910813, 
+                    "seconds_offset_from_start": 285
+                }, 
+                {
+                    "accuracy": 77.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667715, 
+                    "longitude": 26.904631, 
+                    "seconds_offset_from_start": 286
+                }, 
+                {
+                    "accuracy": 90.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665228, 
+                    "longitude": 26.910119, 
+                    "seconds_offset_from_start": 287
+                }, 
+                {
+                    "accuracy": 73.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667669, 
+                    "longitude": 26.905324, 
+                    "seconds_offset_from_start": 288
+                }, 
+                {
+                    "accuracy": 93.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663534, 
+                    "longitude": 26.912187, 
+                    "seconds_offset_from_start": 289
+                }, 
+                {
+                    "accuracy": 91.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665875, 
+                    "longitude": 26.912384, 
+                    "seconds_offset_from_start": 290
+                }, 
+                {
+                    "accuracy": 86.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667651, 
+                    "longitude": 26.911204, 
+                    "seconds_offset_from_start": 291
+                }, 
+                {
+                    "accuracy": 89.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662314, 
+                    "longitude": 26.905087, 
+                    "seconds_offset_from_start": 292
+                }, 
+                {
+                    "accuracy": 68.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661101, 
+                    "longitude": 26.910919, 
+                    "seconds_offset_from_start": 293
+                }, 
+                {
+                    "accuracy": 70.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660097, 
+                    "longitude": 26.903598, 
+                    "seconds_offset_from_start": 294
+                }, 
+                {
+                    "accuracy": 67.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665459, 
+                    "longitude": 26.907341, 
+                    "seconds_offset_from_start": 295
+                }, 
+                {
+                    "accuracy": 73.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667149, 
+                    "longitude": 26.909331, 
+                    "seconds_offset_from_start": 296
+                }, 
+                {
+                    "accuracy": 98.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667485, 
+                    "longitude": 26.906687, 
+                    "seconds_offset_from_start": 297
+                }, 
+                {
+                    "accuracy": 73.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662331, 
+                    "longitude": 26.90407, 
+                    "seconds_offset_from_start": 298
+                }, 
+                {
+                    "accuracy": 61.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66218, 
+                    "longitude": 26.911993, 
+                    "seconds_offset_from_start": 299
+                }, 
+                {
+                    "accuracy": 92.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669181, 
+                    "longitude": 26.906353, 
+                    "seconds_offset_from_start": 300
+                }, 
+                {
+                    "accuracy": 66.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664268, 
+                    "longitude": 26.908452, 
+                    "seconds_offset_from_start": 301
+                }, 
+                {
+                    "accuracy": 73.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664415, 
+                    "longitude": 26.90523, 
+                    "seconds_offset_from_start": 302
+                }, 
+                {
+                    "accuracy": 65.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667975, 
+                    "longitude": 26.902874, 
+                    "seconds_offset_from_start": 303
+                }, 
+                {
+                    "accuracy": 84.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662617, 
+                    "longitude": 26.904918, 
+                    "seconds_offset_from_start": 304
+                }, 
+                {
+                    "accuracy": 89.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664295, 
+                    "longitude": 26.904396, 
+                    "seconds_offset_from_start": 305
+                }, 
+                {
+                    "accuracy": 91.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661062, 
+                    "longitude": 26.912473, 
+                    "seconds_offset_from_start": 306
+                }, 
+                {
+                    "accuracy": 93.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664512, 
+                    "longitude": 26.907371, 
+                    "seconds_offset_from_start": 307
+                }, 
+                {
+                    "accuracy": 64.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667284, 
+                    "longitude": 26.908628, 
+                    "seconds_offset_from_start": 308
+                }, 
+                {
+                    "accuracy": 65.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66484, 
+                    "longitude": 26.909088, 
+                    "seconds_offset_from_start": 309
+                }, 
+                {
+                    "accuracy": 63.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661678, 
+                    "longitude": 26.910313, 
+                    "seconds_offset_from_start": 310
+                }, 
+                {
+                    "accuracy": 100.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665011, 
+                    "longitude": 26.907713, 
+                    "seconds_offset_from_start": 311
+                }, 
+                {
+                    "accuracy": 76.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66049, 
+                    "longitude": 26.91064, 
+                    "seconds_offset_from_start": 312
+                }, 
+                {
+                    "accuracy": 66.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666848, 
+                    "longitude": 26.908045, 
+                    "seconds_offset_from_start": 313
+                }, 
+                {
+                    "accuracy": 60.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669707, 
+                    "longitude": 26.904174, 
+                    "seconds_offset_from_start": 314
+                }, 
+                {
+                    "accuracy": 100.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660286, 
+                    "longitude": 26.909861, 
+                    "seconds_offset_from_start": 315
+                }, 
+                {
+                    "accuracy": 81.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662627, 
+                    "longitude": 26.908227, 
+                    "seconds_offset_from_start": 316
+                }, 
+                {
+                    "accuracy": 68.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66806, 
+                    "longitude": 26.907104, 
+                    "seconds_offset_from_start": 317
+                }, 
+                {
+                    "accuracy": 86.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669146, 
+                    "longitude": 26.909811, 
+                    "seconds_offset_from_start": 318
+                }, 
+                {
+                    "accuracy": 64.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667938, 
+                    "longitude": 26.903984, 
+                    "seconds_offset_from_start": 319
+                }, 
+                {
+                    "accuracy": 60.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661068, 
+                    "longitude": 26.910252, 
+                    "seconds_offset_from_start": 320
+                }, 
+                {
+                    "accuracy": 66.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66583, 
+                    "longitude": 26.909994, 
+                    "seconds_offset_from_start": 321
+                }, 
+                {
+                    "accuracy": 86.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665714, 
+                    "longitude": 26.905013, 
+                    "seconds_offset_from_start": 322
+                }, 
+                {
+                    "accuracy": 85.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664632, 
+                    "longitude": 26.908396, 
+                    "seconds_offset_from_start": 323
+                }, 
+                {
+                    "accuracy": 63.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667442, 
+                    "longitude": 26.904093, 
+                    "seconds_offset_from_start": 324
+                }, 
+                {
+                    "accuracy": 91.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669112, 
+                    "longitude": 26.911689, 
+                    "seconds_offset_from_start": 325
+                }, 
+                {
+                    "accuracy": 99.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661705, 
+                    "longitude": 26.912179, 
+                    "seconds_offset_from_start": 326
+                }, 
+                {
+                    "accuracy": 68.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664876, 
+                    "longitude": 26.911604, 
+                    "seconds_offset_from_start": 327
+                }, 
+                {
+                    "accuracy": 62.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669539, 
+                    "longitude": 26.911024, 
+                    "seconds_offset_from_start": 328
+                }, 
+                {
+                    "accuracy": 98.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664896, 
+                    "longitude": 26.911885, 
+                    "seconds_offset_from_start": 329
+                }, 
+                {
+                    "accuracy": 68.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665353, 
+                    "longitude": 26.906043, 
+                    "seconds_offset_from_start": 330
+                }, 
+                {
+                    "accuracy": 82.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669499, 
+                    "longitude": 26.905787, 
+                    "seconds_offset_from_start": 331
+                }, 
+                {
+                    "accuracy": 100.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665561, 
+                    "longitude": 26.907087, 
+                    "seconds_offset_from_start": 332
+                }, 
+                {
+                    "accuracy": 62.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669661, 
+                    "longitude": 26.911007, 
+                    "seconds_offset_from_start": 333
+                }, 
+                {
+                    "accuracy": 94.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669935, 
+                    "longitude": 26.906947, 
+                    "seconds_offset_from_start": 334
+                }, 
+                {
+                    "accuracy": 68.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665804, 
+                    "longitude": 26.907194, 
+                    "seconds_offset_from_start": 335
+                }, 
+                {
+                    "accuracy": 72.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667444, 
+                    "longitude": 26.908801, 
+                    "seconds_offset_from_start": 336
+                }, 
+                {
+                    "accuracy": 83.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664581, 
+                    "longitude": 26.906394, 
+                    "seconds_offset_from_start": 337
+                }, 
+                {
+                    "accuracy": 76.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664745, 
+                    "longitude": 26.910845, 
+                    "seconds_offset_from_start": 338
+                }, 
+                {
+                    "accuracy": 100.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668633, 
+                    "longitude": 26.9089, 
+                    "seconds_offset_from_start": 339
+                }, 
+                {
+                    "accuracy": 89.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660104, 
+                    "longitude": 26.910096, 
+                    "seconds_offset_from_start": 340
+                }, 
+                {
+                    "accuracy": 75.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665939, 
+                    "longitude": 26.904597, 
+                    "seconds_offset_from_start": 341
+                }, 
+                {
+                    "accuracy": 86.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661697, 
+                    "longitude": 26.904331, 
+                    "seconds_offset_from_start": 342
+                }, 
+                {
+                    "accuracy": 70.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662497, 
+                    "longitude": 26.904376, 
+                    "seconds_offset_from_start": 343
+                }, 
+                {
+                    "accuracy": 100.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667924, 
+                    "longitude": 26.902986, 
+                    "seconds_offset_from_start": 344
+                }, 
+                {
+                    "accuracy": 64.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662861, 
+                    "longitude": 26.906173, 
+                    "seconds_offset_from_start": 345
+                }, 
+                {
+                    "accuracy": 98.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664767, 
+                    "longitude": 26.906258, 
+                    "seconds_offset_from_start": 346
+                }, 
+                {
+                    "accuracy": 66.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664447, 
+                    "longitude": 26.905202, 
+                    "seconds_offset_from_start": 347
+                }, 
+                {
+                    "accuracy": 94.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663873, 
+                    "longitude": 26.90717, 
+                    "seconds_offset_from_start": 348
+                }, 
+                {
+                    "accuracy": 99.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662488, 
+                    "longitude": 26.909914, 
+                    "seconds_offset_from_start": 349
+                }, 
+                {
+                    "accuracy": 69.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664781, 
+                    "longitude": 26.905734, 
+                    "seconds_offset_from_start": 350
+                }, 
+                {
+                    "accuracy": 93.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.6675, 
+                    "longitude": 26.906904, 
+                    "seconds_offset_from_start": 351
+                }, 
+                {
+                    "accuracy": 97.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668269, 
+                    "longitude": 26.905255, 
+                    "seconds_offset_from_start": 352
+                }, 
+                {
+                    "accuracy": 83.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667288, 
+                    "longitude": 26.904908, 
+                    "seconds_offset_from_start": 353
+                }, 
+                {
+                    "accuracy": 89.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662691, 
+                    "longitude": 26.9117, 
+                    "seconds_offset_from_start": 354
+                }, 
+                {
+                    "accuracy": 70.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667107, 
+                    "longitude": 26.908635, 
+                    "seconds_offset_from_start": 355
+                }, 
+                {
+                    "accuracy": 72.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665548, 
+                    "longitude": 26.905438, 
+                    "seconds_offset_from_start": 356
+                }, 
+                {
+                    "accuracy": 95.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665815, 
+                    "longitude": 26.908831, 
+                    "seconds_offset_from_start": 357
+                }, 
+                {
+                    "accuracy": 94.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669492, 
+                    "longitude": 26.90907, 
+                    "seconds_offset_from_start": 358
+                }, 
+                {
+                    "accuracy": 99.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66201, 
+                    "longitude": 26.903507, 
+                    "seconds_offset_from_start": 359
+                }, 
+                {
+                    "accuracy": 87.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668371, 
+                    "longitude": 26.906031, 
+                    "seconds_offset_from_start": 360
+                }, 
+                {
+                    "accuracy": 96.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669711, 
+                    "longitude": 26.909035, 
+                    "seconds_offset_from_start": 361
+                }, 
+                {
+                    "accuracy": 73.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668865, 
+                    "longitude": 26.912269, 
+                    "seconds_offset_from_start": 362
+                }, 
+                {
+                    "accuracy": 86.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664865, 
+                    "longitude": 26.907504, 
+                    "seconds_offset_from_start": 363
+                }, 
+                {
+                    "accuracy": 85.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66247, 
+                    "longitude": 26.907927, 
+                    "seconds_offset_from_start": 364
+                }, 
+                {
+                    "accuracy": 74.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665505, 
+                    "longitude": 26.90319, 
+                    "seconds_offset_from_start": 365
+                }, 
+                {
+                    "accuracy": 93.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66686, 
+                    "longitude": 26.904694, 
+                    "seconds_offset_from_start": 366
+                }, 
+                {
+                    "accuracy": 65.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664633, 
+                    "longitude": 26.908291, 
+                    "seconds_offset_from_start": 367
+                }, 
+                {
+                    "accuracy": 72.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668008, 
+                    "longitude": 26.903727, 
+                    "seconds_offset_from_start": 368
+                }, 
+                {
+                    "accuracy": 89.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660261, 
+                    "longitude": 26.911223, 
+                    "seconds_offset_from_start": 369
+                }, 
+                {
+                    "accuracy": 88.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668058, 
+                    "longitude": 26.907219, 
+                    "seconds_offset_from_start": 370
+                }, 
+                {
+                    "accuracy": 82.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660828, 
+                    "longitude": 26.905804, 
+                    "seconds_offset_from_start": 371
+                }, 
+                {
+                    "accuracy": 81.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662001, 
+                    "longitude": 26.905484, 
+                    "seconds_offset_from_start": 372
+                }, 
+                {
+                    "accuracy": 80.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664478, 
+                    "longitude": 26.906107, 
+                    "seconds_offset_from_start": 373
+                }, 
+                {
+                    "accuracy": 84.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669762, 
+                    "longitude": 26.906543, 
+                    "seconds_offset_from_start": 374
+                }, 
+                {
+                    "accuracy": 65.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664026, 
+                    "longitude": 26.902628, 
+                    "seconds_offset_from_start": 375
+                }, 
+                {
+                    "accuracy": 65.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664082, 
+                    "longitude": 26.905271, 
+                    "seconds_offset_from_start": 376
+                }, 
+                {
+                    "accuracy": 83.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660411, 
+                    "longitude": 26.904422, 
+                    "seconds_offset_from_start": 377
+                }, 
+                {
+                    "accuracy": 71.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663537, 
+                    "longitude": 26.910807, 
+                    "seconds_offset_from_start": 378
+                }, 
+                {
+                    "accuracy": 62.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667227, 
+                    "longitude": 26.90327, 
+                    "seconds_offset_from_start": 379
+                }, 
+                {
+                    "accuracy": 93.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665644, 
+                    "longitude": 26.907689, 
+                    "seconds_offset_from_start": 380
+                }, 
+                {
+                    "accuracy": 60.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666274, 
+                    "longitude": 26.905272, 
+                    "seconds_offset_from_start": 381
+                }, 
+                {
+                    "accuracy": 73.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662029, 
+                    "longitude": 26.904095, 
+                    "seconds_offset_from_start": 382
+                }, 
+                {
+                    "accuracy": 80.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66551, 
+                    "longitude": 26.910385, 
+                    "seconds_offset_from_start": 383
+                }, 
+                {
+                    "accuracy": 78.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66767, 
+                    "longitude": 26.912099, 
+                    "seconds_offset_from_start": 384
+                }, 
+                {
+                    "accuracy": 61.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665039, 
+                    "longitude": 26.91184, 
+                    "seconds_offset_from_start": 385
+                }, 
+                {
+                    "accuracy": 70.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661897, 
+                    "longitude": 26.908875, 
+                    "seconds_offset_from_start": 386
+                }, 
+                {
+                    "accuracy": 88.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66941, 
+                    "longitude": 26.907904, 
+                    "seconds_offset_from_start": 387
+                }, 
+                {
+                    "accuracy": 70.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663857, 
+                    "longitude": 26.908144, 
+                    "seconds_offset_from_start": 388
+                }, 
+                {
+                    "accuracy": 65.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664811, 
+                    "longitude": 26.906822, 
+                    "seconds_offset_from_start": 389
+                }, 
+                {
+                    "accuracy": 70.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668653, 
+                    "longitude": 26.910715, 
+                    "seconds_offset_from_start": 390
+                }, 
+                {
+                    "accuracy": 91.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665196, 
+                    "longitude": 26.906, 
+                    "seconds_offset_from_start": 391
+                }, 
+                {
+                    "accuracy": 66.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666903, 
+                    "longitude": 26.907579, 
+                    "seconds_offset_from_start": 392
+                }, 
+                {
+                    "accuracy": 95.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661404, 
+                    "longitude": 26.909709, 
+                    "seconds_offset_from_start": 393
+                }, 
+                {
+                    "accuracy": 63.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66996, 
+                    "longitude": 26.910824, 
+                    "seconds_offset_from_start": 394
+                }, 
+                {
+                    "accuracy": 64.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661784, 
+                    "longitude": 26.910799, 
+                    "seconds_offset_from_start": 395
+                }, 
+                {
+                    "accuracy": 86.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666928, 
+                    "longitude": 26.912215, 
+                    "seconds_offset_from_start": 396
+                }, 
+                {
+                    "accuracy": 77.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663958, 
+                    "longitude": 26.910258, 
+                    "seconds_offset_from_start": 397
+                }, 
+                {
+                    "accuracy": 93.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661984, 
+                    "longitude": 26.909866, 
+                    "seconds_offset_from_start": 398
+                }, 
+                {
+                    "accuracy": 70.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667808, 
+                    "longitude": 26.909306, 
+                    "seconds_offset_from_start": 399
+                }, 
+                {
+                    "accuracy": 81.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666568, 
+                    "longitude": 26.909955, 
+                    "seconds_offset_from_start": 400
+                }, 
+                {
+                    "accuracy": 64.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668046, 
+                    "longitude": 26.908257, 
+                    "seconds_offset_from_start": 401
+                }, 
+                {
+                    "accuracy": 60.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666601, 
+                    "longitude": 26.905351, 
+                    "seconds_offset_from_start": 402
+                }, 
+                {
+                    "accuracy": 74.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664786, 
+                    "longitude": 26.909637, 
+                    "seconds_offset_from_start": 403
+                }, 
+                {
+                    "accuracy": 66.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666397, 
+                    "longitude": 26.910163, 
+                    "seconds_offset_from_start": 404
+                }, 
+                {
+                    "accuracy": 63.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664332, 
+                    "longitude": 26.903364, 
+                    "seconds_offset_from_start": 405
+                }, 
+                {
+                    "accuracy": 78.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667945, 
+                    "longitude": 26.912011, 
+                    "seconds_offset_from_start": 406
+                }, 
+                {
+                    "accuracy": 85.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663686, 
+                    "longitude": 26.908032, 
+                    "seconds_offset_from_start": 407
+                }, 
+                {
+                    "accuracy": 62.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661978, 
+                    "longitude": 26.902992, 
+                    "seconds_offset_from_start": 408
+                }, 
+                {
+                    "accuracy": 88.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668087, 
+                    "longitude": 26.911794, 
+                    "seconds_offset_from_start": 409
+                }, 
+                {
+                    "accuracy": 96.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664154, 
+                    "longitude": 26.907857, 
+                    "seconds_offset_from_start": 410
+                }, 
+                {
+                    "accuracy": 79.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668178, 
+                    "longitude": 26.911033, 
+                    "seconds_offset_from_start": 411
+                }, 
+                {
+                    "accuracy": 64.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665984, 
+                    "longitude": 26.903755, 
+                    "seconds_offset_from_start": 412
+                }, 
+                {
+                    "accuracy": 79.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661943, 
+                    "longitude": 26.911601, 
+                    "seconds_offset_from_start": 413
+                }, 
+                {
+                    "accuracy": 86.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663205, 
+                    "longitude": 26.904507, 
+                    "seconds_offset_from_start": 414
+                }, 
+                {
+                    "accuracy": 82.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661413, 
+                    "longitude": 26.90803, 
+                    "seconds_offset_from_start": 415
+                }, 
+                {
+                    "accuracy": 73.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665919, 
+                    "longitude": 26.910741, 
+                    "seconds_offset_from_start": 416
+                }, 
+                {
+                    "accuracy": 66.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660286, 
+                    "longitude": 26.904794, 
+                    "seconds_offset_from_start": 417
+                }, 
+                {
+                    "accuracy": 77.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668616, 
+                    "longitude": 26.910839, 
+                    "seconds_offset_from_start": 418
+                }, 
+                {
+                    "accuracy": 89.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665604, 
+                    "longitude": 26.906182, 
+                    "seconds_offset_from_start": 419
+                }, 
+                {
+                    "accuracy": 83.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664698, 
+                    "longitude": 26.907926, 
+                    "seconds_offset_from_start": 420
+                }, 
+                {
+                    "accuracy": 98.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666471, 
+                    "longitude": 26.910816, 
+                    "seconds_offset_from_start": 421
+                }, 
+                {
+                    "accuracy": 81.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666196, 
+                    "longitude": 26.908568, 
+                    "seconds_offset_from_start": 422
+                }, 
+                {
+                    "accuracy": 96.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669367, 
+                    "longitude": 26.910465, 
+                    "seconds_offset_from_start": 423
+                }, 
+                {
+                    "accuracy": 87.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660778, 
+                    "longitude": 26.904589, 
+                    "seconds_offset_from_start": 424
+                }, 
+                {
+                    "accuracy": 80.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.6696, 
+                    "longitude": 26.903081, 
+                    "seconds_offset_from_start": 425
+                }, 
+                {
+                    "accuracy": 91.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664917, 
+                    "longitude": 26.904066, 
+                    "seconds_offset_from_start": 426
+                }, 
+                {
+                    "accuracy": 75.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.6606, 
+                    "longitude": 26.910007, 
+                    "seconds_offset_from_start": 427
+                }, 
+                {
+                    "accuracy": 88.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667732, 
+                    "longitude": 26.903191, 
+                    "seconds_offset_from_start": 428
+                }, 
+                {
+                    "accuracy": 77.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668357, 
+                    "longitude": 26.907667, 
+                    "seconds_offset_from_start": 429
+                }, 
+                {
+                    "accuracy": 61.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665567, 
+                    "longitude": 26.90976, 
+                    "seconds_offset_from_start": 430
+                }, 
+                {
+                    "accuracy": 68.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663185, 
+                    "longitude": 26.906774, 
+                    "seconds_offset_from_start": 431
+                }, 
+                {
+                    "accuracy": 95.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669671, 
+                    "longitude": 26.906082, 
+                    "seconds_offset_from_start": 432
+                }, 
+                {
+                    "accuracy": 87.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666606, 
+                    "longitude": 26.909316, 
+                    "seconds_offset_from_start": 433
+                }, 
+                {
+                    "accuracy": 81.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662795, 
+                    "longitude": 26.903061, 
+                    "seconds_offset_from_start": 434
+                }, 
+                {
+                    "accuracy": 77.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668589, 
+                    "longitude": 26.91232, 
+                    "seconds_offset_from_start": 435
+                }, 
+                {
+                    "accuracy": 88.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664699, 
+                    "longitude": 26.903756, 
+                    "seconds_offset_from_start": 436
+                }, 
+                {
+                    "accuracy": 63.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667527, 
+                    "longitude": 26.906858, 
+                    "seconds_offset_from_start": 437
+                }, 
+                {
+                    "accuracy": 97.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665464, 
+                    "longitude": 26.912026, 
+                    "seconds_offset_from_start": 438
+                }, 
+                {
+                    "accuracy": 86.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662392, 
+                    "longitude": 26.911879, 
+                    "seconds_offset_from_start": 439
+                }, 
+                {
+                    "accuracy": 73.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668915, 
+                    "longitude": 26.903289, 
+                    "seconds_offset_from_start": 440
+                }, 
+                {
+                    "accuracy": 69.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667715, 
+                    "longitude": 26.904412, 
+                    "seconds_offset_from_start": 441
+                }, 
+                {
+                    "accuracy": 98.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668203, 
+                    "longitude": 26.911304, 
+                    "seconds_offset_from_start": 442
+                }, 
+                {
+                    "accuracy": 90.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663269, 
+                    "longitude": 26.905353, 
+                    "seconds_offset_from_start": 443
+                }, 
+                {
+                    "accuracy": 95.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669898, 
+                    "longitude": 26.910926, 
+                    "seconds_offset_from_start": 444
+                }, 
+                {
+                    "accuracy": 60.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662024, 
+                    "longitude": 26.908561, 
+                    "seconds_offset_from_start": 445
+                }, 
+                {
+                    "accuracy": 82.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663544, 
+                    "longitude": 26.902584, 
+                    "seconds_offset_from_start": 446
+                }, 
+                {
+                    "accuracy": 68.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662376, 
+                    "longitude": 26.902799, 
+                    "seconds_offset_from_start": 447
+                }, 
+                {
+                    "accuracy": 67.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661, 
+                    "longitude": 26.903592, 
+                    "seconds_offset_from_start": 448
+                }, 
+                {
+                    "accuracy": 75.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666023, 
+                    "longitude": 26.905763, 
+                    "seconds_offset_from_start": 449
+                }, 
+                {
+                    "accuracy": 72.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669964, 
+                    "longitude": 26.908447, 
+                    "seconds_offset_from_start": 450
+                }, 
+                {
+                    "accuracy": 65.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664194, 
+                    "longitude": 26.912294, 
+                    "seconds_offset_from_start": 451
+                }, 
+                {
+                    "accuracy": 74.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660142, 
+                    "longitude": 26.907556, 
+                    "seconds_offset_from_start": 452
+                }, 
+                {
+                    "accuracy": 95.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665478, 
+                    "longitude": 26.903922, 
+                    "seconds_offset_from_start": 453
+                }, 
+                {
+                    "accuracy": 84.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668324, 
+                    "longitude": 26.91234, 
+                    "seconds_offset_from_start": 454
+                }, 
+                {
+                    "accuracy": 85.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662667, 
+                    "longitude": 26.903817, 
+                    "seconds_offset_from_start": 455
+                }, 
+                {
+                    "accuracy": 65.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664313, 
+                    "longitude": 26.905081, 
+                    "seconds_offset_from_start": 456
+                }, 
+                {
+                    "accuracy": 84.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660662, 
+                    "longitude": 26.911721, 
+                    "seconds_offset_from_start": 457
+                }, 
+                {
+                    "accuracy": 68.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667899, 
+                    "longitude": 26.904018, 
+                    "seconds_offset_from_start": 458
+                }, 
+                {
+                    "accuracy": 72.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662126, 
+                    "longitude": 26.903557, 
+                    "seconds_offset_from_start": 459
+                }, 
+                {
+                    "accuracy": 83.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668185, 
+                    "longitude": 26.911358, 
+                    "seconds_offset_from_start": 460
+                }, 
+                {
+                    "accuracy": 79.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669467, 
+                    "longitude": 26.909917, 
+                    "seconds_offset_from_start": 461
+                }, 
+                {
+                    "accuracy": 88.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665463, 
+                    "longitude": 26.90325, 
+                    "seconds_offset_from_start": 462
+                }, 
+                {
+                    "accuracy": 62.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667373, 
+                    "longitude": 26.903119, 
+                    "seconds_offset_from_start": 463
+                }, 
+                {
+                    "accuracy": 68.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660846, 
+                    "longitude": 26.911104, 
+                    "seconds_offset_from_start": 464
+                }, 
+                {
+                    "accuracy": 94.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663049, 
+                    "longitude": 26.907233, 
+                    "seconds_offset_from_start": 465
+                }, 
+                {
+                    "accuracy": 96.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669244, 
+                    "longitude": 26.907837, 
+                    "seconds_offset_from_start": 466
+                }, 
+                {
+                    "accuracy": 91.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662026, 
+                    "longitude": 26.912029, 
+                    "seconds_offset_from_start": 467
+                }, 
+                {
+                    "accuracy": 73.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666798, 
+                    "longitude": 26.90275, 
+                    "seconds_offset_from_start": 468
+                }, 
+                {
+                    "accuracy": 66.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66397, 
+                    "longitude": 26.911671, 
+                    "seconds_offset_from_start": 469
+                }, 
+                {
+                    "accuracy": 91.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662997, 
+                    "longitude": 26.906135, 
+                    "seconds_offset_from_start": 470
+                }, 
+                {
+                    "accuracy": 94.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664798, 
+                    "longitude": 26.907642, 
+                    "seconds_offset_from_start": 471
+                }, 
+                {
+                    "accuracy": 91.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666487, 
+                    "longitude": 26.903639, 
+                    "seconds_offset_from_start": 472
+                }, 
+                {
+                    "accuracy": 74.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664837, 
+                    "longitude": 26.904899, 
+                    "seconds_offset_from_start": 473
+                }, 
+                {
+                    "accuracy": 68.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663846, 
+                    "longitude": 26.903242, 
+                    "seconds_offset_from_start": 474
+                }, 
+                {
+                    "accuracy": 93.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660139, 
+                    "longitude": 26.910698, 
+                    "seconds_offset_from_start": 475
+                }, 
+                {
+                    "accuracy": 71.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661761, 
+                    "longitude": 26.904045, 
+                    "seconds_offset_from_start": 476
+                }, 
+                {
+                    "accuracy": 69.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663319, 
+                    "longitude": 26.904714, 
+                    "seconds_offset_from_start": 477
+                }, 
+                {
+                    "accuracy": 83.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66945, 
+                    "longitude": 26.908467, 
+                    "seconds_offset_from_start": 478
+                }, 
+                {
+                    "accuracy": 68.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667224, 
+                    "longitude": 26.911338, 
+                    "seconds_offset_from_start": 479
+                }, 
+                {
+                    "accuracy": 73.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661188, 
+                    "longitude": 26.902627, 
+                    "seconds_offset_from_start": 480
+                }, 
+                {
+                    "accuracy": 92.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668063, 
+                    "longitude": 26.906273, 
+                    "seconds_offset_from_start": 481
+                }, 
+                {
+                    "accuracy": 98.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661503, 
+                    "longitude": 26.907051, 
+                    "seconds_offset_from_start": 482
+                }, 
+                {
+                    "accuracy": 71.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669977, 
+                    "longitude": 26.905977, 
+                    "seconds_offset_from_start": 483
+                }, 
+                {
+                    "accuracy": 64.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66726, 
+                    "longitude": 26.902912, 
+                    "seconds_offset_from_start": 484
+                }, 
+                {
+                    "accuracy": 97.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669452, 
+                    "longitude": 26.908515, 
+                    "seconds_offset_from_start": 485
+                }, 
+                {
+                    "accuracy": 99.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663456, 
+                    "longitude": 26.908685, 
+                    "seconds_offset_from_start": 486
+                }, 
+                {
+                    "accuracy": 92.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665494, 
+                    "longitude": 26.906267, 
+                    "seconds_offset_from_start": 487
+                }, 
+                {
+                    "accuracy": 100.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666176, 
+                    "longitude": 26.907876, 
+                    "seconds_offset_from_start": 488
+                }, 
+                {
+                    "accuracy": 75.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666055, 
+                    "longitude": 26.908963, 
+                    "seconds_offset_from_start": 489
+                }, 
+                {
+                    "accuracy": 78.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665201, 
+                    "longitude": 26.91225, 
+                    "seconds_offset_from_start": 490
+                }, 
+                {
+                    "accuracy": 75.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666541, 
+                    "longitude": 26.911015, 
+                    "seconds_offset_from_start": 491
+                }, 
+                {
+                    "accuracy": 63.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663758, 
+                    "longitude": 26.904398, 
+                    "seconds_offset_from_start": 492
+                }, 
+                {
+                    "accuracy": 78.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660696, 
+                    "longitude": 26.910774, 
+                    "seconds_offset_from_start": 493
+                }, 
+                {
+                    "accuracy": 79.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660135, 
+                    "longitude": 26.912229, 
+                    "seconds_offset_from_start": 494
+                }, 
+                {
+                    "accuracy": 85.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668483, 
+                    "longitude": 26.902808, 
+                    "seconds_offset_from_start": 495
+                }, 
+                {
+                    "accuracy": 84.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661862, 
+                    "longitude": 26.903215, 
+                    "seconds_offset_from_start": 496
+                }, 
+                {
+                    "accuracy": 87.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665737, 
+                    "longitude": 26.908346, 
+                    "seconds_offset_from_start": 497
+                }, 
+                {
+                    "accuracy": 83.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666281, 
+                    "longitude": 26.911578, 
+                    "seconds_offset_from_start": 498
+                }, 
+                {
+                    "accuracy": 83.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665054, 
+                    "longitude": 26.904254, 
+                    "seconds_offset_from_start": 499
+                }, 
+                {
+                    "accuracy": 99.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664652, 
+                    "longitude": 26.906389, 
+                    "seconds_offset_from_start": 500
+                }, 
+                {
+                    "accuracy": 75.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669731, 
+                    "longitude": 26.904333, 
+                    "seconds_offset_from_start": 501
+                }, 
+                {
+                    "accuracy": 90.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667999, 
+                    "longitude": 26.908306, 
+                    "seconds_offset_from_start": 502
+                }, 
+                {
+                    "accuracy": 66.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664298, 
+                    "longitude": 26.907548, 
+                    "seconds_offset_from_start": 503
+                }, 
+                {
+                    "accuracy": 89.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661123, 
+                    "longitude": 26.912307, 
+                    "seconds_offset_from_start": 504
+                }, 
+                {
+                    "accuracy": 81.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668105, 
+                    "longitude": 26.902897, 
+                    "seconds_offset_from_start": 505
+                }, 
+                {
+                    "accuracy": 94.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667127, 
+                    "longitude": 26.907547, 
+                    "seconds_offset_from_start": 506
+                }, 
+                {
+                    "accuracy": 96.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667554, 
+                    "longitude": 26.911957, 
+                    "seconds_offset_from_start": 507
+                }, 
+                {
+                    "accuracy": 99.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661688, 
+                    "longitude": 26.906319, 
+                    "seconds_offset_from_start": 508
+                }, 
+                {
+                    "accuracy": 72.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66902, 
+                    "longitude": 26.904339, 
+                    "seconds_offset_from_start": 509
+                }, 
+                {
+                    "accuracy": 90.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66041, 
+                    "longitude": 26.905127, 
+                    "seconds_offset_from_start": 510
+                }, 
+                {
+                    "accuracy": 96.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664366, 
+                    "longitude": 26.912448, 
+                    "seconds_offset_from_start": 511
+                }, 
+                {
+                    "accuracy": 91.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668081, 
+                    "longitude": 26.907279, 
+                    "seconds_offset_from_start": 512
+                }, 
+                {
+                    "accuracy": 70.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661626, 
+                    "longitude": 26.909312, 
+                    "seconds_offset_from_start": 513
+                }, 
+                {
+                    "accuracy": 80.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666455, 
+                    "longitude": 26.909743, 
+                    "seconds_offset_from_start": 514
+                }, 
+                {
+                    "accuracy": 97.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662143, 
+                    "longitude": 26.911481, 
+                    "seconds_offset_from_start": 515
+                }, 
+                {
+                    "accuracy": 97.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666957, 
+                    "longitude": 26.907539, 
+                    "seconds_offset_from_start": 516
+                }, 
+                {
+                    "accuracy": 78.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667266, 
+                    "longitude": 26.909276, 
+                    "seconds_offset_from_start": 517
+                }, 
+                {
+                    "accuracy": 74.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668806, 
+                    "longitude": 26.90326, 
+                    "seconds_offset_from_start": 518
+                }, 
+                {
+                    "accuracy": 94.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662514, 
+                    "longitude": 26.904152, 
+                    "seconds_offset_from_start": 519
+                }, 
+                {
+                    "accuracy": 74.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664502, 
+                    "longitude": 26.904619, 
+                    "seconds_offset_from_start": 520
+                }, 
+                {
+                    "accuracy": 92.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660308, 
+                    "longitude": 26.907204, 
+                    "seconds_offset_from_start": 521
+                }, 
+                {
+                    "accuracy": 72.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663456, 
+                    "longitude": 26.909929, 
+                    "seconds_offset_from_start": 522
+                }, 
+                {
+                    "accuracy": 68.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661974, 
+                    "longitude": 26.911929, 
+                    "seconds_offset_from_start": 523
+                }, 
+                {
+                    "accuracy": 71.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665707, 
+                    "longitude": 26.903702, 
+                    "seconds_offset_from_start": 524
+                }, 
+                {
+                    "accuracy": 74.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666036, 
+                    "longitude": 26.911233, 
+                    "seconds_offset_from_start": 525
+                }, 
+                {
+                    "accuracy": 79.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663157, 
+                    "longitude": 26.906027, 
+                    "seconds_offset_from_start": 526
+                }, 
+                {
+                    "accuracy": 85.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664239, 
+                    "longitude": 26.906881, 
+                    "seconds_offset_from_start": 527
+                }, 
+                {
+                    "accuracy": 98.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669247, 
+                    "longitude": 26.912096, 
+                    "seconds_offset_from_start": 528
+                }, 
+                {
+                    "accuracy": 91.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668534, 
+                    "longitude": 26.909339, 
+                    "seconds_offset_from_start": 529
+                }, 
+                {
+                    "accuracy": 100.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667241, 
+                    "longitude": 26.909228, 
+                    "seconds_offset_from_start": 530
+                }, 
+                {
+                    "accuracy": 98.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665993, 
+                    "longitude": 26.908449, 
+                    "seconds_offset_from_start": 531
+                }, 
+                {
+                    "accuracy": 64.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661324, 
+                    "longitude": 26.903567, 
+                    "seconds_offset_from_start": 532
+                }, 
+                {
+                    "accuracy": 76.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660982, 
+                    "longitude": 26.906173, 
+                    "seconds_offset_from_start": 533
+                }, 
+                {
+                    "accuracy": 81.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663056, 
+                    "longitude": 26.906617, 
+                    "seconds_offset_from_start": 534
+                }, 
+                {
+                    "accuracy": 80.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667231, 
+                    "longitude": 26.908975, 
+                    "seconds_offset_from_start": 535
+                }, 
+                {
+                    "accuracy": 95.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666544, 
+                    "longitude": 26.90401, 
+                    "seconds_offset_from_start": 536
+                }, 
+                {
+                    "accuracy": 78.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667568, 
+                    "longitude": 26.90947, 
+                    "seconds_offset_from_start": 537
+                }, 
+                {
+                    "accuracy": 97.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666241, 
+                    "longitude": 26.910135, 
+                    "seconds_offset_from_start": 538
+                }, 
+                {
+                    "accuracy": 95.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660729, 
+                    "longitude": 26.904854, 
+                    "seconds_offset_from_start": 539
+                }, 
+                {
+                    "accuracy": 97.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667281, 
+                    "longitude": 26.911274, 
+                    "seconds_offset_from_start": 540
+                }, 
+                {
+                    "accuracy": 89.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667499, 
+                    "longitude": 26.910074, 
+                    "seconds_offset_from_start": 541
+                }, 
+                {
+                    "accuracy": 77.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667368, 
+                    "longitude": 26.912447, 
+                    "seconds_offset_from_start": 542
+                }, 
+                {
+                    "accuracy": 81.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665699, 
+                    "longitude": 26.905372, 
+                    "seconds_offset_from_start": 543
+                }, 
+                {
+                    "accuracy": 68.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663499, 
+                    "longitude": 26.911785, 
+                    "seconds_offset_from_start": 544
+                }, 
+                {
+                    "accuracy": 62.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667285, 
+                    "longitude": 26.903959, 
+                    "seconds_offset_from_start": 545
+                }, 
+                {
+                    "accuracy": 65.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663738, 
+                    "longitude": 26.90949, 
+                    "seconds_offset_from_start": 546
+                }, 
+                {
+                    "accuracy": 99.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662536, 
+                    "longitude": 26.904988, 
+                    "seconds_offset_from_start": 547
+                }, 
+                {
+                    "accuracy": 96.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665632, 
+                    "longitude": 26.904857, 
+                    "seconds_offset_from_start": 548
+                }, 
+                {
+                    "accuracy": 92.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663607, 
+                    "longitude": 26.907078, 
+                    "seconds_offset_from_start": 549
+                }, 
+                {
+                    "accuracy": 71.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660715, 
+                    "longitude": 26.902898, 
+                    "seconds_offset_from_start": 550
+                }, 
+                {
+                    "accuracy": 67.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668589, 
+                    "longitude": 26.909836, 
+                    "seconds_offset_from_start": 551
+                }, 
+                {
+                    "accuracy": 74.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662349, 
+                    "longitude": 26.907597, 
+                    "seconds_offset_from_start": 552
+                }, 
+                {
+                    "accuracy": 64.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667283, 
+                    "longitude": 26.912059, 
+                    "seconds_offset_from_start": 553
+                }, 
+                {
+                    "accuracy": 71.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668395, 
+                    "longitude": 26.903934, 
+                    "seconds_offset_from_start": 554
+                }, 
+                {
+                    "accuracy": 60.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661566, 
+                    "longitude": 26.909308, 
+                    "seconds_offset_from_start": 555
+                }, 
+                {
+                    "accuracy": 98.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661261, 
+                    "longitude": 26.903896, 
+                    "seconds_offset_from_start": 556
+                }, 
+                {
+                    "accuracy": 60.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667034, 
+                    "longitude": 26.904903, 
+                    "seconds_offset_from_start": 557
+                }, 
+                {
+                    "accuracy": 64.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664914, 
+                    "longitude": 26.903361, 
+                    "seconds_offset_from_start": 558
+                }, 
+                {
+                    "accuracy": 72.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666351, 
+                    "longitude": 26.908762, 
+                    "seconds_offset_from_start": 559
+                }, 
+                {
+                    "accuracy": 92.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660106, 
+                    "longitude": 26.904394, 
+                    "seconds_offset_from_start": 560
+                }, 
+                {
+                    "accuracy": 96.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665019, 
+                    "longitude": 26.903997, 
+                    "seconds_offset_from_start": 561
+                }, 
+                {
+                    "accuracy": 67.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662232, 
+                    "longitude": 26.909, 
+                    "seconds_offset_from_start": 562
+                }, 
+                {
+                    "accuracy": 91.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663494, 
+                    "longitude": 26.904157, 
+                    "seconds_offset_from_start": 563
+                }, 
+                {
+                    "accuracy": 69.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663229, 
+                    "longitude": 26.906454, 
+                    "seconds_offset_from_start": 564
+                }, 
+                {
+                    "accuracy": 95.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660829, 
+                    "longitude": 26.909023, 
+                    "seconds_offset_from_start": 565
+                }, 
+                {
+                    "accuracy": 87.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668809, 
+                    "longitude": 26.907026, 
+                    "seconds_offset_from_start": 566
+                }, 
+                {
+                    "accuracy": 87.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665053, 
+                    "longitude": 26.907981, 
+                    "seconds_offset_from_start": 567
+                }, 
+                {
+                    "accuracy": 71.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662919, 
+                    "longitude": 26.904983, 
+                    "seconds_offset_from_start": 568
+                }, 
+                {
+                    "accuracy": 71.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664312, 
+                    "longitude": 26.902684, 
+                    "seconds_offset_from_start": 569
+                }, 
+                {
+                    "accuracy": 94.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669057, 
+                    "longitude": 26.904628, 
+                    "seconds_offset_from_start": 570
+                }, 
+                {
+                    "accuracy": 86.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66943, 
+                    "longitude": 26.905029, 
+                    "seconds_offset_from_start": 571
+                }, 
+                {
+                    "accuracy": 73.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664422, 
+                    "longitude": 26.904484, 
+                    "seconds_offset_from_start": 572
+                }, 
+                {
+                    "accuracy": 84.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669793, 
+                    "longitude": 26.907757, 
+                    "seconds_offset_from_start": 573
+                }, 
+                {
+                    "accuracy": 69.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660532, 
+                    "longitude": 26.904775, 
+                    "seconds_offset_from_start": 574
+                }, 
+                {
+                    "accuracy": 91.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667452, 
+                    "longitude": 26.908987, 
+                    "seconds_offset_from_start": 575
+                }, 
+                {
+                    "accuracy": 70.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666373, 
+                    "longitude": 26.911735, 
+                    "seconds_offset_from_start": 576
+                }, 
+                {
+                    "accuracy": 97.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663011, 
+                    "longitude": 26.90752, 
+                    "seconds_offset_from_start": 577
+                }, 
+                {
+                    "accuracy": 61.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66443, 
+                    "longitude": 26.905037, 
+                    "seconds_offset_from_start": 578
+                }, 
+                {
+                    "accuracy": 86.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663363, 
+                    "longitude": 26.9039, 
+                    "seconds_offset_from_start": 579
+                }, 
+                {
+                    "accuracy": 87.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668519, 
+                    "longitude": 26.904855, 
+                    "seconds_offset_from_start": 580
+                }, 
+                {
+                    "accuracy": 63.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666231, 
+                    "longitude": 26.912162, 
+                    "seconds_offset_from_start": 581
+                }, 
+                {
+                    "accuracy": 83.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661696, 
+                    "longitude": 26.909197, 
+                    "seconds_offset_from_start": 582
+                }, 
+                {
+                    "accuracy": 86.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664584, 
+                    "longitude": 26.902907, 
+                    "seconds_offset_from_start": 583
+                }, 
+                {
+                    "accuracy": 77.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666589, 
+                    "longitude": 26.904373, 
+                    "seconds_offset_from_start": 584
+                }, 
+                {
+                    "accuracy": 95.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669108, 
+                    "longitude": 26.911273, 
+                    "seconds_offset_from_start": 585
+                }, 
+                {
+                    "accuracy": 84.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663674, 
+                    "longitude": 26.904817, 
+                    "seconds_offset_from_start": 586
+                }, 
+                {
+                    "accuracy": 96.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667765, 
+                    "longitude": 26.910015, 
+                    "seconds_offset_from_start": 587
+                }, 
+                {
+                    "accuracy": 78.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66136, 
+                    "longitude": 26.907578, 
+                    "seconds_offset_from_start": 588
+                }, 
+                {
+                    "accuracy": 74.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.6651, 
+                    "longitude": 26.911951, 
+                    "seconds_offset_from_start": 589
+                }, 
+                {
+                    "accuracy": 78.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667546, 
+                    "longitude": 26.903612, 
+                    "seconds_offset_from_start": 590
+                }, 
+                {
+                    "accuracy": 73.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660296, 
+                    "longitude": 26.905701, 
+                    "seconds_offset_from_start": 591
+                }, 
+                {
+                    "accuracy": 89.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662796, 
+                    "longitude": 26.908921, 
+                    "seconds_offset_from_start": 592
+                }, 
+                {
+                    "accuracy": 74.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665794, 
+                    "longitude": 26.902778, 
+                    "seconds_offset_from_start": 593
+                }, 
+                {
+                    "accuracy": 62.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664878, 
+                    "longitude": 26.904529, 
+                    "seconds_offset_from_start": 594
+                }, 
+                {
+                    "accuracy": 84.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666649, 
+                    "longitude": 26.909318, 
+                    "seconds_offset_from_start": 595
+                }, 
+                {
+                    "accuracy": 62.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663183, 
+                    "longitude": 26.905164, 
+                    "seconds_offset_from_start": 596
+                }, 
+                {
+                    "accuracy": 87.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662193, 
+                    "longitude": 26.90295, 
+                    "seconds_offset_from_start": 597
+                }, 
+                {
+                    "accuracy": 81.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668825, 
+                    "longitude": 26.909089, 
+                    "seconds_offset_from_start": 598
+                }, 
+                {
+                    "accuracy": 96.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669777, 
+                    "longitude": 26.903482, 
+                    "seconds_offset_from_start": 599
+                }, 
+                {
+                    "accuracy": 72.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668991, 
+                    "longitude": 26.908993, 
+                    "seconds_offset_from_start": 600
+                }, 
+                {
+                    "accuracy": 65.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66696, 
+                    "longitude": 26.905707, 
+                    "seconds_offset_from_start": 601
+                }, 
+                {
+                    "accuracy": 66.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662786, 
+                    "longitude": 26.905674, 
+                    "seconds_offset_from_start": 602
+                }, 
+                {
+                    "accuracy": 100.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667718, 
+                    "longitude": 26.910555, 
+                    "seconds_offset_from_start": 603
+                }, 
+                {
+                    "accuracy": 63.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669418, 
+                    "longitude": 26.906624, 
+                    "seconds_offset_from_start": 604
+                }, 
+                {
+                    "accuracy": 65.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662006, 
+                    "longitude": 26.902719, 
+                    "seconds_offset_from_start": 605
+                }, 
+                {
+                    "accuracy": 79.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663589, 
+                    "longitude": 26.903691, 
+                    "seconds_offset_from_start": 606
+                }, 
+                {
+                    "accuracy": 74.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666412, 
+                    "longitude": 26.911076, 
+                    "seconds_offset_from_start": 607
+                }, 
+                {
+                    "accuracy": 94.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665864, 
+                    "longitude": 26.90467, 
+                    "seconds_offset_from_start": 608
+                }, 
+                {
+                    "accuracy": 69.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660173, 
+                    "longitude": 26.907719, 
+                    "seconds_offset_from_start": 609
+                }, 
+                {
+                    "accuracy": 70.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664628, 
+                    "longitude": 26.906868, 
+                    "seconds_offset_from_start": 610
+                }, 
+                {
+                    "accuracy": 64.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667053, 
+                    "longitude": 26.911812, 
+                    "seconds_offset_from_start": 611
+                }, 
+                {
+                    "accuracy": 64.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665338, 
+                    "longitude": 26.907399, 
+                    "seconds_offset_from_start": 612
+                }, 
+                {
+                    "accuracy": 86.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669505, 
+                    "longitude": 26.907576, 
+                    "seconds_offset_from_start": 613
+                }, 
+                {
+                    "accuracy": 90.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662513, 
+                    "longitude": 26.902976, 
+                    "seconds_offset_from_start": 614
+                }, 
+                {
+                    "accuracy": 98.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665523, 
+                    "longitude": 26.904541, 
+                    "seconds_offset_from_start": 615
+                }, 
+                {
+                    "accuracy": 98.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661042, 
+                    "longitude": 26.905765, 
+                    "seconds_offset_from_start": 616
+                }, 
+                {
+                    "accuracy": 60.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664239, 
+                    "longitude": 26.907925, 
+                    "seconds_offset_from_start": 617
+                }, 
+                {
+                    "accuracy": 85.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661094, 
+                    "longitude": 26.906049, 
+                    "seconds_offset_from_start": 618
+                }, 
+                {
+                    "accuracy": 62.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66448, 
+                    "longitude": 26.910963, 
+                    "seconds_offset_from_start": 619
+                }, 
+                {
+                    "accuracy": 77.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664862, 
+                    "longitude": 26.906132, 
+                    "seconds_offset_from_start": 620
+                }, 
+                {
+                    "accuracy": 60.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667544, 
+                    "longitude": 26.906996, 
+                    "seconds_offset_from_start": 621
+                }, 
+                {
+                    "accuracy": 71.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663529, 
+                    "longitude": 26.908041, 
+                    "seconds_offset_from_start": 622
+                }, 
+                {
+                    "accuracy": 80.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665046, 
+                    "longitude": 26.904687, 
+                    "seconds_offset_from_start": 623
+                }, 
+                {
+                    "accuracy": 91.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665707, 
+                    "longitude": 26.911107, 
+                    "seconds_offset_from_start": 624
+                }, 
+                {
+                    "accuracy": 65.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668158, 
+                    "longitude": 26.907885, 
+                    "seconds_offset_from_start": 625
+                }, 
+                {
+                    "accuracy": 62.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665946, 
+                    "longitude": 26.911298, 
+                    "seconds_offset_from_start": 626
+                }, 
+                {
+                    "accuracy": 85.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666998, 
+                    "longitude": 26.904899, 
+                    "seconds_offset_from_start": 627
+                }, 
+                {
+                    "accuracy": 88.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666747, 
+                    "longitude": 26.910629, 
+                    "seconds_offset_from_start": 628
+                }, 
+                {
+                    "accuracy": 61.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66596, 
+                    "longitude": 26.907609, 
+                    "seconds_offset_from_start": 629
+                }, 
+                {
+                    "accuracy": 67.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665768, 
+                    "longitude": 26.905902, 
+                    "seconds_offset_from_start": 630
+                }, 
+                {
+                    "accuracy": 95.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664242, 
+                    "longitude": 26.908564, 
+                    "seconds_offset_from_start": 631
+                }, 
+                {
+                    "accuracy": 91.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664136, 
+                    "longitude": 26.90793, 
+                    "seconds_offset_from_start": 632
+                }, 
+                {
+                    "accuracy": 73.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669419, 
+                    "longitude": 26.908459, 
+                    "seconds_offset_from_start": 633
+                }, 
+                {
+                    "accuracy": 89.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660584, 
+                    "longitude": 26.904907, 
+                    "seconds_offset_from_start": 634
+                }, 
+                {
+                    "accuracy": 73.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664331, 
+                    "longitude": 26.907653, 
+                    "seconds_offset_from_start": 635
+                }, 
+                {
+                    "accuracy": 78.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668269, 
+                    "longitude": 26.912225, 
+                    "seconds_offset_from_start": 636
+                }, 
+                {
+                    "accuracy": 60.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669574, 
+                    "longitude": 26.907066, 
+                    "seconds_offset_from_start": 637
+                }, 
+                {
+                    "accuracy": 82.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663998, 
+                    "longitude": 26.911699, 
+                    "seconds_offset_from_start": 638
+                }, 
+                {
+                    "accuracy": 92.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668666, 
+                    "longitude": 26.908391, 
+                    "seconds_offset_from_start": 639
+                }, 
+                {
+                    "accuracy": 80.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660024, 
+                    "longitude": 26.902911, 
+                    "seconds_offset_from_start": 640
+                }, 
+                {
+                    "accuracy": 77.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669249, 
+                    "longitude": 26.906458, 
+                    "seconds_offset_from_start": 641
+                }, 
+                {
+                    "accuracy": 62.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667898, 
+                    "longitude": 26.912161, 
+                    "seconds_offset_from_start": 642
+                }, 
+                {
+                    "accuracy": 89.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668508, 
+                    "longitude": 26.902956, 
+                    "seconds_offset_from_start": 643
+                }, 
+                {
+                    "accuracy": 67.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662858, 
+                    "longitude": 26.907599, 
+                    "seconds_offset_from_start": 644
+                }, 
+                {
+                    "accuracy": 60.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662749, 
+                    "longitude": 26.904692, 
+                    "seconds_offset_from_start": 645
+                }, 
+                {
+                    "accuracy": 76.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664329, 
+                    "longitude": 26.910253, 
+                    "seconds_offset_from_start": 646
+                }, 
+                {
+                    "accuracy": 71.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660669, 
+                    "longitude": 26.906459, 
+                    "seconds_offset_from_start": 647
+                }, 
+                {
+                    "accuracy": 80.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669037, 
+                    "longitude": 26.903203, 
+                    "seconds_offset_from_start": 648
+                }, 
+                {
+                    "accuracy": 65.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660515, 
+                    "longitude": 26.909838, 
+                    "seconds_offset_from_start": 649
+                }, 
+                {
+                    "accuracy": 93.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661766, 
+                    "longitude": 26.904269, 
+                    "seconds_offset_from_start": 650
+                }, 
+                {
+                    "accuracy": 77.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665842, 
+                    "longitude": 26.908088, 
+                    "seconds_offset_from_start": 651
+                }, 
+                {
+                    "accuracy": 87.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665692, 
+                    "longitude": 26.905534, 
+                    "seconds_offset_from_start": 652
+                }, 
+                {
+                    "accuracy": 89.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666238, 
+                    "longitude": 26.908456, 
+                    "seconds_offset_from_start": 653
+                }, 
+                {
+                    "accuracy": 99.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669761, 
+                    "longitude": 26.906427, 
+                    "seconds_offset_from_start": 654
+                }, 
+                {
+                    "accuracy": 73.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660043, 
+                    "longitude": 26.905115, 
+                    "seconds_offset_from_start": 655
+                }, 
+                {
+                    "accuracy": 91.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663388, 
+                    "longitude": 26.90302, 
+                    "seconds_offset_from_start": 656
+                }, 
+                {
+                    "accuracy": 62.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666667, 
+                    "longitude": 26.9052, 
+                    "seconds_offset_from_start": 657
+                }, 
+                {
+                    "accuracy": 75.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662975, 
+                    "longitude": 26.90252, 
+                    "seconds_offset_from_start": 658
+                }, 
+                {
+                    "accuracy": 86.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669072, 
+                    "longitude": 26.9073, 
+                    "seconds_offset_from_start": 659
+                }, 
+                {
+                    "accuracy": 78.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668845, 
+                    "longitude": 26.907067, 
+                    "seconds_offset_from_start": 660
+                }, 
+                {
+                    "accuracy": 77.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668233, 
+                    "longitude": 26.90415, 
+                    "seconds_offset_from_start": 661
+                }, 
+                {
+                    "accuracy": 78.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669355, 
+                    "longitude": 26.90723, 
+                    "seconds_offset_from_start": 662
+                }, 
+                {
+                    "accuracy": 78.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660072, 
+                    "longitude": 26.906137, 
+                    "seconds_offset_from_start": 663
+                }, 
+                {
+                    "accuracy": 71.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665612, 
+                    "longitude": 26.91144, 
+                    "seconds_offset_from_start": 664
+                }, 
+                {
+                    "accuracy": 71.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665297, 
+                    "longitude": 26.903287, 
+                    "seconds_offset_from_start": 665
+                }, 
+                {
+                    "accuracy": 91.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668292, 
+                    "longitude": 26.909434, 
+                    "seconds_offset_from_start": 666
+                }, 
+                {
+                    "accuracy": 77.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66581, 
+                    "longitude": 26.905639, 
+                    "seconds_offset_from_start": 667
+                }, 
+                {
+                    "accuracy": 92.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662864, 
+                    "longitude": 26.907946, 
+                    "seconds_offset_from_start": 668
+                }, 
+                {
+                    "accuracy": 99.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66231, 
+                    "longitude": 26.905856, 
+                    "seconds_offset_from_start": 669
+                }, 
+                {
+                    "accuracy": 78.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667058, 
+                    "longitude": 26.908405, 
+                    "seconds_offset_from_start": 670
+                }, 
+                {
+                    "accuracy": 61.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661441, 
+                    "longitude": 26.905862, 
+                    "seconds_offset_from_start": 671
+                }, 
+                {
+                    "accuracy": 64.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666308, 
+                    "longitude": 26.905802, 
+                    "seconds_offset_from_start": 672
+                }, 
+                {
+                    "accuracy": 65.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669342, 
+                    "longitude": 26.904969, 
+                    "seconds_offset_from_start": 673
+                }, 
+                {
+                    "accuracy": 94.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66128, 
+                    "longitude": 26.906043, 
+                    "seconds_offset_from_start": 674
+                }, 
+                {
+                    "accuracy": 75.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668928, 
+                    "longitude": 26.909126, 
+                    "seconds_offset_from_start": 675
+                }, 
+                {
+                    "accuracy": 85.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668762, 
+                    "longitude": 26.911658, 
+                    "seconds_offset_from_start": 676
+                }, 
+                {
+                    "accuracy": 85.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661047, 
+                    "longitude": 26.908481, 
+                    "seconds_offset_from_start": 677
+                }, 
+                {
+                    "accuracy": 84.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668604, 
+                    "longitude": 26.907237, 
+                    "seconds_offset_from_start": 678
+                }, 
+                {
+                    "accuracy": 88.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661137, 
+                    "longitude": 26.911887, 
+                    "seconds_offset_from_start": 679
+                }, 
+                {
+                    "accuracy": 70.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664289, 
+                    "longitude": 26.911407, 
+                    "seconds_offset_from_start": 680
+                }, 
+                {
+                    "accuracy": 83.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665091, 
+                    "longitude": 26.903705, 
+                    "seconds_offset_from_start": 681
+                }, 
+                {
+                    "accuracy": 79.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663223, 
+                    "longitude": 26.911214, 
+                    "seconds_offset_from_start": 682
+                }, 
+                {
+                    "accuracy": 92.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664241, 
+                    "longitude": 26.902532, 
+                    "seconds_offset_from_start": 683
+                }, 
+                {
+                    "accuracy": 66.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665905, 
+                    "longitude": 26.907953, 
+                    "seconds_offset_from_start": 684
+                }, 
+                {
+                    "accuracy": 69.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660455, 
+                    "longitude": 26.903276, 
+                    "seconds_offset_from_start": 685
+                }, 
+                {
+                    "accuracy": 97.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666438, 
+                    "longitude": 26.907147, 
+                    "seconds_offset_from_start": 686
+                }, 
+                {
+                    "accuracy": 63.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666315, 
+                    "longitude": 26.907773, 
+                    "seconds_offset_from_start": 687
+                }, 
+                {
+                    "accuracy": 82.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660216, 
+                    "longitude": 26.909738, 
+                    "seconds_offset_from_start": 688
+                }, 
+                {
+                    "accuracy": 90.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66417, 
+                    "longitude": 26.910055, 
+                    "seconds_offset_from_start": 689
+                }, 
+                {
+                    "accuracy": 70.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662777, 
+                    "longitude": 26.911285, 
+                    "seconds_offset_from_start": 690
+                }, 
+                {
+                    "accuracy": 75.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667222, 
+                    "longitude": 26.908135, 
+                    "seconds_offset_from_start": 691
+                }, 
+                {
+                    "accuracy": 72.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66579, 
+                    "longitude": 26.904072, 
+                    "seconds_offset_from_start": 692
+                }, 
+                {
+                    "accuracy": 60.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665191, 
+                    "longitude": 26.911268, 
+                    "seconds_offset_from_start": 693
+                }, 
+                {
+                    "accuracy": 60.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665228, 
+                    "longitude": 26.902562, 
+                    "seconds_offset_from_start": 694
+                }, 
+                {
+                    "accuracy": 84.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669365, 
+                    "longitude": 26.91143, 
+                    "seconds_offset_from_start": 695
+                }, 
+                {
+                    "accuracy": 79.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663678, 
+                    "longitude": 26.905295, 
+                    "seconds_offset_from_start": 696
+                }, 
+                {
+                    "accuracy": 65.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666271, 
+                    "longitude": 26.910787, 
+                    "seconds_offset_from_start": 697
+                }, 
+                {
+                    "accuracy": 94.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661958, 
+                    "longitude": 26.911813, 
+                    "seconds_offset_from_start": 698
+                }, 
+                {
+                    "accuracy": 79.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664809, 
+                    "longitude": 26.912029, 
+                    "seconds_offset_from_start": 699
+                }, 
+                {
+                    "accuracy": 79.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668186, 
+                    "longitude": 26.907552, 
+                    "seconds_offset_from_start": 700
+                }, 
+                {
+                    "accuracy": 61.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66023, 
+                    "longitude": 26.907823, 
+                    "seconds_offset_from_start": 701
+                }, 
+                {
+                    "accuracy": 61.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662464, 
+                    "longitude": 26.910585, 
+                    "seconds_offset_from_start": 702
+                }, 
+                {
+                    "accuracy": 83.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660728, 
+                    "longitude": 26.912055, 
+                    "seconds_offset_from_start": 703
+                }, 
+                {
+                    "accuracy": 90.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669424, 
+                    "longitude": 26.902896, 
+                    "seconds_offset_from_start": 704
+                }, 
+                {
+                    "accuracy": 87.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664599, 
+                    "longitude": 26.908019, 
+                    "seconds_offset_from_start": 705
+                }, 
+                {
+                    "accuracy": 87.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660341, 
+                    "longitude": 26.910294, 
+                    "seconds_offset_from_start": 706
+                }, 
+                {
+                    "accuracy": 64.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663464, 
+                    "longitude": 26.908671, 
+                    "seconds_offset_from_start": 707
+                }, 
+                {
+                    "accuracy": 87.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663202, 
+                    "longitude": 26.908582, 
+                    "seconds_offset_from_start": 708
+                }, 
+                {
+                    "accuracy": 76.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662471, 
+                    "longitude": 26.902665, 
+                    "seconds_offset_from_start": 709
+                }, 
+                {
+                    "accuracy": 68.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668036, 
+                    "longitude": 26.909367, 
+                    "seconds_offset_from_start": 710
+                }, 
+                {
+                    "accuracy": 63.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665161, 
+                    "longitude": 26.903995, 
+                    "seconds_offset_from_start": 711
+                }, 
+                {
+                    "accuracy": 78.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66236, 
+                    "longitude": 26.90675, 
+                    "seconds_offset_from_start": 712
+                }, 
+                {
+                    "accuracy": 62.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668607, 
+                    "longitude": 26.908043, 
+                    "seconds_offset_from_start": 713
+                }, 
+                {
+                    "accuracy": 68.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663888, 
+                    "longitude": 26.903196, 
+                    "seconds_offset_from_start": 714
+                }, 
+                {
+                    "accuracy": 65.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664309, 
+                    "longitude": 26.910633, 
+                    "seconds_offset_from_start": 715
+                }, 
+                {
+                    "accuracy": 65.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666511, 
+                    "longitude": 26.910609, 
+                    "seconds_offset_from_start": 716
+                }, 
+                {
+                    "accuracy": 78.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661116, 
+                    "longitude": 26.909576, 
+                    "seconds_offset_from_start": 717
+                }, 
+                {
+                    "accuracy": 78.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669959, 
+                    "longitude": 26.905612, 
+                    "seconds_offset_from_start": 718
+                }, 
+                {
+                    "accuracy": 63.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660789, 
+                    "longitude": 26.908106, 
+                    "seconds_offset_from_start": 719
+                }, 
+                {
+                    "accuracy": 63.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665749, 
+                    "longitude": 26.906286, 
+                    "seconds_offset_from_start": 720
+                }, 
+                {
+                    "accuracy": 65.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669522, 
+                    "longitude": 26.911691, 
+                    "seconds_offset_from_start": 721
+                }, 
+                {
+                    "accuracy": 62.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662078, 
+                    "longitude": 26.911913, 
+                    "seconds_offset_from_start": 722
+                }, 
+                {
+                    "accuracy": 76.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665722, 
+                    "longitude": 26.90586, 
+                    "seconds_offset_from_start": 723
+                }, 
+                {
+                    "accuracy": 90.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666672, 
+                    "longitude": 26.90462, 
+                    "seconds_offset_from_start": 724
+                }, 
+                {
+                    "accuracy": 82.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661823, 
+                    "longitude": 26.912428, 
+                    "seconds_offset_from_start": 725
+                }, 
+                {
+                    "accuracy": 75.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665147, 
+                    "longitude": 26.909999, 
+                    "seconds_offset_from_start": 726
+                }, 
+                {
+                    "accuracy": 64.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663391, 
+                    "longitude": 26.905814, 
+                    "seconds_offset_from_start": 727
+                }, 
+                {
+                    "accuracy": 79.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661, 
+                    "longitude": 26.911165, 
+                    "seconds_offset_from_start": 728
+                }, 
+                {
+                    "accuracy": 90.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66603, 
+                    "longitude": 26.910497, 
+                    "seconds_offset_from_start": 729
+                }, 
+                {
+                    "accuracy": 100.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66141, 
+                    "longitude": 26.905202, 
+                    "seconds_offset_from_start": 730
+                }, 
+                {
+                    "accuracy": 65.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665582, 
+                    "longitude": 26.910564, 
+                    "seconds_offset_from_start": 731
+                }, 
+                {
+                    "accuracy": 78.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669017, 
+                    "longitude": 26.909067, 
+                    "seconds_offset_from_start": 732
+                }, 
+                {
+                    "accuracy": 83.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664174, 
+                    "longitude": 26.902769, 
+                    "seconds_offset_from_start": 733
+                }, 
+                {
+                    "accuracy": 82.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66218, 
+                    "longitude": 26.909328, 
+                    "seconds_offset_from_start": 734
+                }, 
+                {
+                    "accuracy": 84.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663805, 
+                    "longitude": 26.910093, 
+                    "seconds_offset_from_start": 735
+                }, 
+                {
+                    "accuracy": 60.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667549, 
+                    "longitude": 26.904345, 
+                    "seconds_offset_from_start": 736
+                }, 
+                {
+                    "accuracy": 62.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665795, 
+                    "longitude": 26.904829, 
+                    "seconds_offset_from_start": 737
+                }, 
+                {
+                    "accuracy": 65.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66477, 
+                    "longitude": 26.904232, 
+                    "seconds_offset_from_start": 738
+                }, 
+                {
+                    "accuracy": 79.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668331, 
+                    "longitude": 26.906736, 
+                    "seconds_offset_from_start": 739
+                }, 
+                {
+                    "accuracy": 72.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66401, 
+                    "longitude": 26.910465, 
+                    "seconds_offset_from_start": 740
+                }, 
+                {
+                    "accuracy": 87.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666734, 
+                    "longitude": 26.905997, 
+                    "seconds_offset_from_start": 741
+                }, 
+                {
+                    "accuracy": 91.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660126, 
+                    "longitude": 26.904955, 
+                    "seconds_offset_from_start": 742
+                }, 
+                {
+                    "accuracy": 91.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665853, 
+                    "longitude": 26.909509, 
+                    "seconds_offset_from_start": 743
+                }, 
+                {
+                    "accuracy": 92.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661545, 
+                    "longitude": 26.906017, 
+                    "seconds_offset_from_start": 744
+                }, 
+                {
+                    "accuracy": 94.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667569, 
+                    "longitude": 26.906304, 
+                    "seconds_offset_from_start": 745
+                }, 
+                {
+                    "accuracy": 60.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663235, 
+                    "longitude": 26.90914, 
+                    "seconds_offset_from_start": 746
+                }, 
+                {
+                    "accuracy": 63.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668864, 
+                    "longitude": 26.903653, 
+                    "seconds_offset_from_start": 747
+                }, 
+                {
+                    "accuracy": 64.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665871, 
+                    "longitude": 26.91138, 
+                    "seconds_offset_from_start": 748
+                }, 
+                {
+                    "accuracy": 85.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667835, 
+                    "longitude": 26.905884, 
+                    "seconds_offset_from_start": 749
+                }, 
+                {
+                    "accuracy": 77.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669923, 
+                    "longitude": 26.905402, 
+                    "seconds_offset_from_start": 750
+                }, 
+                {
+                    "accuracy": 99.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669788, 
+                    "longitude": 26.907243, 
+                    "seconds_offset_from_start": 751
+                }, 
+                {
+                    "accuracy": 68.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669263, 
+                    "longitude": 26.90331, 
+                    "seconds_offset_from_start": 752
+                }, 
+                {
+                    "accuracy": 100.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669647, 
+                    "longitude": 26.904373, 
+                    "seconds_offset_from_start": 753
+                }, 
+                {
+                    "accuracy": 90.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666703, 
+                    "longitude": 26.908843, 
+                    "seconds_offset_from_start": 754
+                }, 
+                {
+                    "accuracy": 75.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665904, 
+                    "longitude": 26.906857, 
+                    "seconds_offset_from_start": 755
+                }, 
+                {
+                    "accuracy": 88.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667708, 
+                    "longitude": 26.909492, 
+                    "seconds_offset_from_start": 756
+                }, 
+                {
+                    "accuracy": 76.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664213, 
+                    "longitude": 26.903273, 
+                    "seconds_offset_from_start": 757
+                }, 
+                {
+                    "accuracy": 80.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660265, 
+                    "longitude": 26.906957, 
+                    "seconds_offset_from_start": 758
+                }, 
+                {
+                    "accuracy": 61.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662357, 
+                    "longitude": 26.905715, 
+                    "seconds_offset_from_start": 759
+                }, 
+                {
+                    "accuracy": 85.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662312, 
+                    "longitude": 26.908507, 
+                    "seconds_offset_from_start": 760
+                }, 
+                {
+                    "accuracy": 66.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669772, 
+                    "longitude": 26.905784, 
+                    "seconds_offset_from_start": 761
+                }, 
+                {
+                    "accuracy": 81.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664189, 
+                    "longitude": 26.911598, 
+                    "seconds_offset_from_start": 762
+                }, 
+                {
+                    "accuracy": 85.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662496, 
+                    "longitude": 26.907193, 
+                    "seconds_offset_from_start": 763
+                }, 
+                {
+                    "accuracy": 91.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669694, 
+                    "longitude": 26.910985, 
+                    "seconds_offset_from_start": 764
+                }, 
+                {
+                    "accuracy": 94.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664313, 
+                    "longitude": 26.908895, 
+                    "seconds_offset_from_start": 765
+                }, 
+                {
+                    "accuracy": 72.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667082, 
+                    "longitude": 26.908601, 
+                    "seconds_offset_from_start": 766
+                }, 
+                {
+                    "accuracy": 81.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666871, 
+                    "longitude": 26.908823, 
+                    "seconds_offset_from_start": 767
+                }, 
+                {
+                    "accuracy": 60.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663965, 
+                    "longitude": 26.907487, 
+                    "seconds_offset_from_start": 768
+                }, 
+                {
+                    "accuracy": 61.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660885, 
+                    "longitude": 26.907489, 
+                    "seconds_offset_from_start": 769
+                }, 
+                {
+                    "accuracy": 76.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664455, 
+                    "longitude": 26.905268, 
+                    "seconds_offset_from_start": 770
+                }, 
+                {
+                    "accuracy": 76.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663848, 
+                    "longitude": 26.90402, 
+                    "seconds_offset_from_start": 771
+                }, 
+                {
+                    "accuracy": 89.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66282, 
+                    "longitude": 26.90362, 
+                    "seconds_offset_from_start": 772
+                }, 
+                {
+                    "accuracy": 69.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66136, 
+                    "longitude": 26.910546, 
+                    "seconds_offset_from_start": 773
+                }, 
+                {
+                    "accuracy": 88.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665941, 
+                    "longitude": 26.90951, 
+                    "seconds_offset_from_start": 774
+                }, 
+                {
+                    "accuracy": 98.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664851, 
+                    "longitude": 26.911494, 
+                    "seconds_offset_from_start": 775
+                }, 
+                {
+                    "accuracy": 92.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662001, 
+                    "longitude": 26.912313, 
+                    "seconds_offset_from_start": 776
+                }, 
+                {
+                    "accuracy": 93.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667382, 
+                    "longitude": 26.907038, 
+                    "seconds_offset_from_start": 777
+                }, 
+                {
+                    "accuracy": 76.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663338, 
+                    "longitude": 26.912211, 
+                    "seconds_offset_from_start": 778
+                }, 
+                {
+                    "accuracy": 64.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666199, 
+                    "longitude": 26.906328, 
+                    "seconds_offset_from_start": 779
+                }, 
+                {
+                    "accuracy": 81.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668938, 
+                    "longitude": 26.905607, 
+                    "seconds_offset_from_start": 780
+                }, 
+                {
+                    "accuracy": 70.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663438, 
+                    "longitude": 26.904784, 
+                    "seconds_offset_from_start": 781
+                }, 
+                {
+                    "accuracy": 78.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667633, 
+                    "longitude": 26.910772, 
+                    "seconds_offset_from_start": 782
+                }, 
+                {
+                    "accuracy": 71.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660445, 
+                    "longitude": 26.909178, 
+                    "seconds_offset_from_start": 783
+                }, 
+                {
+                    "accuracy": 81.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66262, 
+                    "longitude": 26.910106, 
+                    "seconds_offset_from_start": 784
+                }, 
+                {
+                    "accuracy": 66.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669118, 
+                    "longitude": 26.910697, 
+                    "seconds_offset_from_start": 785
+                }, 
+                {
+                    "accuracy": 68.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661644, 
+                    "longitude": 26.904965, 
+                    "seconds_offset_from_start": 786
+                }, 
+                {
+                    "accuracy": 78.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66702, 
+                    "longitude": 26.910645, 
+                    "seconds_offset_from_start": 787
+                }, 
+                {
+                    "accuracy": 85.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660526, 
+                    "longitude": 26.908537, 
+                    "seconds_offset_from_start": 788
+                }, 
+                {
+                    "accuracy": 96.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660337, 
+                    "longitude": 26.905489, 
+                    "seconds_offset_from_start": 789
+                }, 
+                {
+                    "accuracy": 91.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667516, 
+                    "longitude": 26.912493, 
+                    "seconds_offset_from_start": 790
+                }, 
+                {
+                    "accuracy": 87.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666202, 
+                    "longitude": 26.904046, 
+                    "seconds_offset_from_start": 791
+                }, 
+                {
+                    "accuracy": 72.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663132, 
+                    "longitude": 26.905425, 
+                    "seconds_offset_from_start": 792
+                }, 
+                {
+                    "accuracy": 94.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664535, 
+                    "longitude": 26.902636, 
+                    "seconds_offset_from_start": 793
+                }, 
+                {
+                    "accuracy": 99.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66148, 
+                    "longitude": 26.906018, 
+                    "seconds_offset_from_start": 794
+                }, 
+                {
+                    "accuracy": 86.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669838, 
+                    "longitude": 26.904058, 
+                    "seconds_offset_from_start": 795
+                }, 
+                {
+                    "accuracy": 91.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660685, 
+                    "longitude": 26.903598, 
+                    "seconds_offset_from_start": 796
+                }, 
+                {
+                    "accuracy": 87.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66851, 
+                    "longitude": 26.906677, 
+                    "seconds_offset_from_start": 797
+                }, 
+                {
+                    "accuracy": 64.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663523, 
+                    "longitude": 26.905127, 
+                    "seconds_offset_from_start": 798
+                }, 
+                {
+                    "accuracy": 63.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667538, 
+                    "longitude": 26.91136, 
+                    "seconds_offset_from_start": 799
+                }, 
+                {
+                    "accuracy": 67.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661588, 
+                    "longitude": 26.906778, 
+                    "seconds_offset_from_start": 800
+                }, 
+                {
+                    "accuracy": 67.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665526, 
+                    "longitude": 26.906076, 
+                    "seconds_offset_from_start": 801
+                }, 
+                {
+                    "accuracy": 80.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663694, 
+                    "longitude": 26.903844, 
+                    "seconds_offset_from_start": 802
+                }, 
+                {
+                    "accuracy": 81.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668803, 
+                    "longitude": 26.906856, 
+                    "seconds_offset_from_start": 803
+                }, 
+                {
+                    "accuracy": 99.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663902, 
+                    "longitude": 26.91123, 
+                    "seconds_offset_from_start": 804
+                }, 
+                {
+                    "accuracy": 79.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664615, 
+                    "longitude": 26.906456, 
+                    "seconds_offset_from_start": 805
+                }, 
+                {
+                    "accuracy": 68.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663071, 
+                    "longitude": 26.906811, 
+                    "seconds_offset_from_start": 806
+                }, 
+                {
+                    "accuracy": 72.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665542, 
+                    "longitude": 26.909571, 
+                    "seconds_offset_from_start": 807
+                }, 
+                {
+                    "accuracy": 68.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664466, 
+                    "longitude": 26.910562, 
+                    "seconds_offset_from_start": 808
+                }, 
+                {
+                    "accuracy": 89.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660529, 
+                    "longitude": 26.902561, 
+                    "seconds_offset_from_start": 809
+                }, 
+                {
+                    "accuracy": 68.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665667, 
+                    "longitude": 26.904021, 
+                    "seconds_offset_from_start": 810
+                }, 
+                {
+                    "accuracy": 62.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663239, 
+                    "longitude": 26.908118, 
+                    "seconds_offset_from_start": 811
+                }, 
+                {
+                    "accuracy": 73.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667761, 
+                    "longitude": 26.911347, 
+                    "seconds_offset_from_start": 812
+                }, 
+                {
+                    "accuracy": 83.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660715, 
+                    "longitude": 26.907348, 
+                    "seconds_offset_from_start": 813
+                }, 
+                {
+                    "accuracy": 83.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668086, 
+                    "longitude": 26.910993, 
+                    "seconds_offset_from_start": 814
+                }, 
+                {
+                    "accuracy": 80.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66811, 
+                    "longitude": 26.904178, 
+                    "seconds_offset_from_start": 815
+                }, 
+                {
+                    "accuracy": 100.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666203, 
+                    "longitude": 26.911684, 
+                    "seconds_offset_from_start": 816
+                }, 
+                {
+                    "accuracy": 68.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668489, 
+                    "longitude": 26.909594, 
+                    "seconds_offset_from_start": 817
+                }, 
+                {
+                    "accuracy": 67.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663425, 
+                    "longitude": 26.903061, 
+                    "seconds_offset_from_start": 818
+                }, 
+                {
+                    "accuracy": 75.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660472, 
+                    "longitude": 26.907162, 
+                    "seconds_offset_from_start": 819
+                }, 
+                {
+                    "accuracy": 96.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66564, 
+                    "longitude": 26.909483, 
+                    "seconds_offset_from_start": 820
+                }, 
+                {
+                    "accuracy": 80.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666065, 
+                    "longitude": 26.908361, 
+                    "seconds_offset_from_start": 821
+                }, 
+                {
+                    "accuracy": 97.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662433, 
+                    "longitude": 26.905372, 
+                    "seconds_offset_from_start": 822
+                }, 
+                {
+                    "accuracy": 83.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665441, 
+                    "longitude": 26.908132, 
+                    "seconds_offset_from_start": 823
+                }, 
+                {
+                    "accuracy": 75.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667788, 
+                    "longitude": 26.903552, 
+                    "seconds_offset_from_start": 824
+                }, 
+                {
+                    "accuracy": 68.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664688, 
+                    "longitude": 26.903889, 
+                    "seconds_offset_from_start": 825
+                }, 
+                {
+                    "accuracy": 72.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661772, 
+                    "longitude": 26.906186, 
+                    "seconds_offset_from_start": 826
+                }, 
+                {
+                    "accuracy": 60.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661125, 
+                    "longitude": 26.90756, 
+                    "seconds_offset_from_start": 827
+                }, 
+                {
+                    "accuracy": 85.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664903, 
+                    "longitude": 26.903348, 
+                    "seconds_offset_from_start": 828
+                }, 
+                {
+                    "accuracy": 65.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664835, 
+                    "longitude": 26.90283, 
+                    "seconds_offset_from_start": 829
+                }, 
+                {
+                    "accuracy": 72.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662675, 
+                    "longitude": 26.902584, 
+                    "seconds_offset_from_start": 830
+                }, 
+                {
+                    "accuracy": 89.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660609, 
+                    "longitude": 26.911634, 
+                    "seconds_offset_from_start": 831
+                }, 
+                {
+                    "accuracy": 71.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661766, 
+                    "longitude": 26.911121, 
+                    "seconds_offset_from_start": 832
+                }, 
+                {
+                    "accuracy": 78.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666934, 
+                    "longitude": 26.909714, 
+                    "seconds_offset_from_start": 833
+                }, 
+                {
+                    "accuracy": 80.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662951, 
+                    "longitude": 26.910505, 
+                    "seconds_offset_from_start": 834
+                }, 
+                {
+                    "accuracy": 74.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663023, 
+                    "longitude": 26.90733, 
+                    "seconds_offset_from_start": 835
+                }, 
+                {
+                    "accuracy": 71.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666207, 
+                    "longitude": 26.905849, 
+                    "seconds_offset_from_start": 836
+                }, 
+                {
+                    "accuracy": 90.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660274, 
+                    "longitude": 26.902684, 
+                    "seconds_offset_from_start": 837
+                }, 
+                {
+                    "accuracy": 99.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668892, 
+                    "longitude": 26.903409, 
+                    "seconds_offset_from_start": 838
+                }, 
+                {
+                    "accuracy": 83.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661515, 
+                    "longitude": 26.908053, 
+                    "seconds_offset_from_start": 839
+                }, 
+                {
+                    "accuracy": 79.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663706, 
+                    "longitude": 26.907807, 
+                    "seconds_offset_from_start": 840
+                }, 
+                {
+                    "accuracy": 91.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663237, 
+                    "longitude": 26.908671, 
+                    "seconds_offset_from_start": 841
+                }, 
+                {
+                    "accuracy": 90.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663778, 
+                    "longitude": 26.907013, 
+                    "seconds_offset_from_start": 842
+                }, 
+                {
+                    "accuracy": 75.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668448, 
+                    "longitude": 26.902982, 
+                    "seconds_offset_from_start": 843
+                }, 
+                {
+                    "accuracy": 97.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663719, 
+                    "longitude": 26.908083, 
+                    "seconds_offset_from_start": 844
+                }, 
+                {
+                    "accuracy": 93.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661943, 
+                    "longitude": 26.906037, 
+                    "seconds_offset_from_start": 845
+                }, 
+                {
+                    "accuracy": 70.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666244, 
+                    "longitude": 26.9037, 
+                    "seconds_offset_from_start": 846
+                }, 
+                {
+                    "accuracy": 65.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667662, 
+                    "longitude": 26.905427, 
+                    "seconds_offset_from_start": 847
+                }, 
+                {
+                    "accuracy": 73.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66905, 
+                    "longitude": 26.910341, 
+                    "seconds_offset_from_start": 848
+                }, 
+                {
+                    "accuracy": 61.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660906, 
+                    "longitude": 26.910979, 
+                    "seconds_offset_from_start": 849
+                }, 
+                {
+                    "accuracy": 91.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665337, 
+                    "longitude": 26.911992, 
+                    "seconds_offset_from_start": 850
+                }, 
+                {
+                    "accuracy": 94.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660056, 
+                    "longitude": 26.90697, 
+                    "seconds_offset_from_start": 851
+                }, 
+                {
+                    "accuracy": 70.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660349, 
+                    "longitude": 26.908117, 
+                    "seconds_offset_from_start": 852
+                }, 
+                {
+                    "accuracy": 72.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669288, 
+                    "longitude": 26.904093, 
+                    "seconds_offset_from_start": 853
+                }, 
+                {
+                    "accuracy": 79.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664453, 
+                    "longitude": 26.904295, 
+                    "seconds_offset_from_start": 854
+                }, 
+                {
+                    "accuracy": 83.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664261, 
+                    "longitude": 26.906334, 
+                    "seconds_offset_from_start": 855
+                }, 
+                {
+                    "accuracy": 81.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660279, 
+                    "longitude": 26.904515, 
+                    "seconds_offset_from_start": 856
+                }, 
+                {
+                    "accuracy": 91.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661515, 
+                    "longitude": 26.911734, 
+                    "seconds_offset_from_start": 857
+                }, 
+                {
+                    "accuracy": 72.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660099, 
+                    "longitude": 26.90714, 
+                    "seconds_offset_from_start": 858
+                }, 
+                {
+                    "accuracy": 61.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660969, 
+                    "longitude": 26.905913, 
+                    "seconds_offset_from_start": 859
+                }, 
+                {
+                    "accuracy": 71.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660836, 
+                    "longitude": 26.905476, 
+                    "seconds_offset_from_start": 860
+                }, 
+                {
+                    "accuracy": 98.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669326, 
+                    "longitude": 26.910909, 
+                    "seconds_offset_from_start": 861
+                }, 
+                {
+                    "accuracy": 67.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664414, 
+                    "longitude": 26.902681, 
+                    "seconds_offset_from_start": 862
+                }, 
+                {
+                    "accuracy": 89.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663249, 
+                    "longitude": 26.909851, 
+                    "seconds_offset_from_start": 863
+                }, 
+                {
+                    "accuracy": 64.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660161, 
+                    "longitude": 26.905342, 
+                    "seconds_offset_from_start": 864
+                }, 
+                {
+                    "accuracy": 76.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66776, 
+                    "longitude": 26.905513, 
+                    "seconds_offset_from_start": 865
+                }, 
+                {
+                    "accuracy": 97.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66094, 
+                    "longitude": 26.909314, 
+                    "seconds_offset_from_start": 866
+                }, 
+                {
+                    "accuracy": 60.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665264, 
+                    "longitude": 26.909531, 
+                    "seconds_offset_from_start": 867
+                }, 
+                {
+                    "accuracy": 84.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661966, 
+                    "longitude": 26.903838, 
+                    "seconds_offset_from_start": 868
+                }, 
+                {
+                    "accuracy": 63.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667142, 
+                    "longitude": 26.903917, 
+                    "seconds_offset_from_start": 869
+                }, 
+                {
+                    "accuracy": 83.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663764, 
+                    "longitude": 26.906616, 
+                    "seconds_offset_from_start": 870
+                }, 
+                {
+                    "accuracy": 74.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666107, 
+                    "longitude": 26.905084, 
+                    "seconds_offset_from_start": 871
+                }, 
+                {
+                    "accuracy": 96.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663103, 
+                    "longitude": 26.902532, 
+                    "seconds_offset_from_start": 872
+                }, 
+                {
+                    "accuracy": 93.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663708, 
+                    "longitude": 26.906542, 
+                    "seconds_offset_from_start": 873
+                }, 
+                {
+                    "accuracy": 87.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663627, 
+                    "longitude": 26.911508, 
+                    "seconds_offset_from_start": 874
+                }, 
+                {
+                    "accuracy": 84.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668419, 
+                    "longitude": 26.90876, 
+                    "seconds_offset_from_start": 875
+                }, 
+                {
+                    "accuracy": 69.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668809, 
+                    "longitude": 26.904198, 
+                    "seconds_offset_from_start": 876
+                }, 
+                {
+                    "accuracy": 72.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662742, 
+                    "longitude": 26.911744, 
+                    "seconds_offset_from_start": 877
+                }, 
+                {
+                    "accuracy": 75.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665806, 
+                    "longitude": 26.907697, 
+                    "seconds_offset_from_start": 878
+                }, 
+                {
+                    "accuracy": 89.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66729, 
+                    "longitude": 26.91104, 
+                    "seconds_offset_from_start": 879
+                }, 
+                {
+                    "accuracy": 69.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668739, 
+                    "longitude": 26.903462, 
+                    "seconds_offset_from_start": 880
+                }, 
+                {
+                    "accuracy": 70.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669761, 
+                    "longitude": 26.910796, 
+                    "seconds_offset_from_start": 881
+                }, 
+                {
+                    "accuracy": 97.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660173, 
+                    "longitude": 26.908565, 
+                    "seconds_offset_from_start": 882
+                }, 
+                {
+                    "accuracy": 77.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667314, 
+                    "longitude": 26.903565, 
+                    "seconds_offset_from_start": 883
+                }, 
+                {
+                    "accuracy": 64.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666036, 
+                    "longitude": 26.911642, 
+                    "seconds_offset_from_start": 884
+                }, 
+                {
+                    "accuracy": 60.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666466, 
+                    "longitude": 26.907335, 
+                    "seconds_offset_from_start": 885
+                }, 
+                {
+                    "accuracy": 86.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66131, 
+                    "longitude": 26.911512, 
+                    "seconds_offset_from_start": 886
+                }, 
+                {
+                    "accuracy": 88.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669472, 
+                    "longitude": 26.910416, 
+                    "seconds_offset_from_start": 887
+                }, 
+                {
+                    "accuracy": 63.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667279, 
+                    "longitude": 26.9112, 
+                    "seconds_offset_from_start": 888
+                }, 
+                {
+                    "accuracy": 83.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662556, 
+                    "longitude": 26.905108, 
+                    "seconds_offset_from_start": 889
+                }, 
+                {
+                    "accuracy": 68.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667586, 
+                    "longitude": 26.911825, 
+                    "seconds_offset_from_start": 890
+                }, 
+                {
+                    "accuracy": 63.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663249, 
+                    "longitude": 26.905181, 
+                    "seconds_offset_from_start": 891
+                }, 
+                {
+                    "accuracy": 70.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66851, 
+                    "longitude": 26.90361, 
+                    "seconds_offset_from_start": 892
+                }, 
+                {
+                    "accuracy": 81.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661654, 
+                    "longitude": 26.904044, 
+                    "seconds_offset_from_start": 893
+                }, 
+                {
+                    "accuracy": 77.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66585, 
+                    "longitude": 26.906876, 
+                    "seconds_offset_from_start": 894
+                }, 
+                {
+                    "accuracy": 74.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666613, 
+                    "longitude": 26.909746, 
+                    "seconds_offset_from_start": 895
+                }, 
+                {
+                    "accuracy": 85.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66157, 
+                    "longitude": 26.907376, 
+                    "seconds_offset_from_start": 896
+                }, 
+                {
+                    "accuracy": 79.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668747, 
+                    "longitude": 26.902738, 
+                    "seconds_offset_from_start": 897
+                }, 
+                {
+                    "accuracy": 65.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668319, 
+                    "longitude": 26.911949, 
+                    "seconds_offset_from_start": 898
+                }, 
+                {
+                    "accuracy": 72.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665979, 
+                    "longitude": 26.91092, 
+                    "seconds_offset_from_start": 899
+                }, 
+                {
+                    "accuracy": 69.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661445, 
+                    "longitude": 26.908965, 
+                    "seconds_offset_from_start": 900
+                }, 
+                {
+                    "accuracy": 98.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667597, 
+                    "longitude": 26.910136, 
+                    "seconds_offset_from_start": 901
+                }, 
+                {
+                    "accuracy": 76.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66026, 
+                    "longitude": 26.903144, 
+                    "seconds_offset_from_start": 902
+                }, 
+                {
+                    "accuracy": 64.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664689, 
+                    "longitude": 26.909118, 
+                    "seconds_offset_from_start": 903
+                }, 
+                {
+                    "accuracy": 66.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668006, 
+                    "longitude": 26.903813, 
+                    "seconds_offset_from_start": 904
+                }, 
+                {
+                    "accuracy": 90.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666007, 
+                    "longitude": 26.908543, 
+                    "seconds_offset_from_start": 905
+                }, 
+                {
+                    "accuracy": 100.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66607, 
+                    "longitude": 26.909428, 
+                    "seconds_offset_from_start": 906
+                }, 
+                {
+                    "accuracy": 77.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666197, 
+                    "longitude": 26.90887, 
+                    "seconds_offset_from_start": 907
+                }, 
+                {
+                    "accuracy": 70.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666156, 
+                    "longitude": 26.904709, 
+                    "seconds_offset_from_start": 908
+                }, 
+                {
+                    "accuracy": 63.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662459, 
+                    "longitude": 26.907263, 
+                    "seconds_offset_from_start": 909
+                }, 
+                {
+                    "accuracy": 65.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665815, 
+                    "longitude": 26.911852, 
+                    "seconds_offset_from_start": 910
+                }, 
+                {
+                    "accuracy": 60.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665991, 
+                    "longitude": 26.909213, 
+                    "seconds_offset_from_start": 911
+                }, 
+                {
+                    "accuracy": 100.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666441, 
+                    "longitude": 26.905906, 
+                    "seconds_offset_from_start": 912
+                }, 
+                {
+                    "accuracy": 69.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665273, 
+                    "longitude": 26.90462, 
+                    "seconds_offset_from_start": 913
+                }, 
+                {
+                    "accuracy": 77.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664049, 
+                    "longitude": 26.906747, 
+                    "seconds_offset_from_start": 914
+                }, 
+                {
+                    "accuracy": 64.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667283, 
+                    "longitude": 26.911406, 
+                    "seconds_offset_from_start": 915
+                }, 
+                {
+                    "accuracy": 64.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669865, 
+                    "longitude": 26.902723, 
+                    "seconds_offset_from_start": 916
+                }, 
+                {
+                    "accuracy": 86.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665237, 
+                    "longitude": 26.905418, 
+                    "seconds_offset_from_start": 917
+                }, 
+                {
+                    "accuracy": 95.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661897, 
+                    "longitude": 26.910501, 
+                    "seconds_offset_from_start": 918
+                }, 
+                {
+                    "accuracy": 61.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669514, 
+                    "longitude": 26.903714, 
+                    "seconds_offset_from_start": 919
+                }, 
+                {
+                    "accuracy": 96.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668181, 
+                    "longitude": 26.90334, 
+                    "seconds_offset_from_start": 920
+                }, 
+                {
+                    "accuracy": 98.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669796, 
+                    "longitude": 26.907554, 
+                    "seconds_offset_from_start": 921
+                }, 
+                {
+                    "accuracy": 60.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666659, 
+                    "longitude": 26.909293, 
+                    "seconds_offset_from_start": 922
+                }, 
+                {
+                    "accuracy": 91.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663725, 
+                    "longitude": 26.908847, 
+                    "seconds_offset_from_start": 923
+                }, 
+                {
+                    "accuracy": 94.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66819, 
+                    "longitude": 26.910324, 
+                    "seconds_offset_from_start": 924
+                }, 
+                {
+                    "accuracy": 78.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669585, 
+                    "longitude": 26.903403, 
+                    "seconds_offset_from_start": 925
+                }, 
+                {
+                    "accuracy": 63.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668018, 
+                    "longitude": 26.905038, 
+                    "seconds_offset_from_start": 926
+                }, 
+                {
+                    "accuracy": 69.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66279, 
+                    "longitude": 26.908154, 
+                    "seconds_offset_from_start": 927
+                }, 
+                {
+                    "accuracy": 77.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665458, 
+                    "longitude": 26.907528, 
+                    "seconds_offset_from_start": 928
+                }, 
+                {
+                    "accuracy": 82.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664866, 
+                    "longitude": 26.911177, 
+                    "seconds_offset_from_start": 929
+                }, 
+                {
+                    "accuracy": 100.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666083, 
+                    "longitude": 26.90986, 
+                    "seconds_offset_from_start": 930
+                }, 
+                {
+                    "accuracy": 70.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664633, 
+                    "longitude": 26.902648, 
+                    "seconds_offset_from_start": 931
+                }, 
+                {
+                    "accuracy": 99.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665819, 
+                    "longitude": 26.909503, 
+                    "seconds_offset_from_start": 932
+                }, 
+                {
+                    "accuracy": 62.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668916, 
+                    "longitude": 26.911889, 
+                    "seconds_offset_from_start": 933
+                }, 
+                {
+                    "accuracy": 65.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667988, 
+                    "longitude": 26.911998, 
+                    "seconds_offset_from_start": 934
+                }, 
+                {
+                    "accuracy": 88.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662356, 
+                    "longitude": 26.907545, 
+                    "seconds_offset_from_start": 935
+                }, 
+                {
+                    "accuracy": 65.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662139, 
+                    "longitude": 26.908285, 
+                    "seconds_offset_from_start": 936
+                }, 
+                {
+                    "accuracy": 95.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667409, 
+                    "longitude": 26.908072, 
+                    "seconds_offset_from_start": 937
+                }, 
+                {
+                    "accuracy": 83.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665978, 
+                    "longitude": 26.909613, 
+                    "seconds_offset_from_start": 938
+                }, 
+                {
+                    "accuracy": 98.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660004, 
+                    "longitude": 26.90505, 
+                    "seconds_offset_from_start": 939
+                }, 
+                {
+                    "accuracy": 94.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66072, 
+                    "longitude": 26.903649, 
+                    "seconds_offset_from_start": 940
+                }, 
+                {
+                    "accuracy": 94.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667089, 
+                    "longitude": 26.906577, 
+                    "seconds_offset_from_start": 941
+                }, 
+                {
+                    "accuracy": 84.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665113, 
+                    "longitude": 26.909163, 
+                    "seconds_offset_from_start": 942
+                }, 
+                {
+                    "accuracy": 70.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669969, 
+                    "longitude": 26.908602, 
+                    "seconds_offset_from_start": 943
+                }, 
+                {
+                    "accuracy": 90.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660218, 
+                    "longitude": 26.907751, 
+                    "seconds_offset_from_start": 944
+                }, 
+                {
+                    "accuracy": 95.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662386, 
+                    "longitude": 26.907113, 
+                    "seconds_offset_from_start": 945
+                }, 
+                {
+                    "accuracy": 76.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668145, 
+                    "longitude": 26.909429, 
+                    "seconds_offset_from_start": 946
+                }, 
+                {
+                    "accuracy": 89.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667624, 
+                    "longitude": 26.907007, 
+                    "seconds_offset_from_start": 947
+                }, 
+                {
+                    "accuracy": 63.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662427, 
+                    "longitude": 26.904633, 
+                    "seconds_offset_from_start": 948
+                }, 
+                {
+                    "accuracy": 77.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667471, 
+                    "longitude": 26.909397, 
+                    "seconds_offset_from_start": 949
+                }, 
+                {
+                    "accuracy": 64.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661149, 
+                    "longitude": 26.90348, 
+                    "seconds_offset_from_start": 950
+                }, 
+                {
+                    "accuracy": 69.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661536, 
+                    "longitude": 26.911919, 
+                    "seconds_offset_from_start": 951
+                }, 
+                {
+                    "accuracy": 69.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665542, 
+                    "longitude": 26.912445, 
+                    "seconds_offset_from_start": 952
+                }, 
+                {
+                    "accuracy": 65.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666247, 
+                    "longitude": 26.907694, 
+                    "seconds_offset_from_start": 953
+                }, 
+                {
+                    "accuracy": 92.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664211, 
+                    "longitude": 26.910572, 
+                    "seconds_offset_from_start": 954
+                }, 
+                {
+                    "accuracy": 75.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662302, 
+                    "longitude": 26.905254, 
+                    "seconds_offset_from_start": 955
+                }, 
+                {
+                    "accuracy": 99.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662544, 
+                    "longitude": 26.903041, 
+                    "seconds_offset_from_start": 956
+                }, 
+                {
+                    "accuracy": 93.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668412, 
+                    "longitude": 26.910961, 
+                    "seconds_offset_from_start": 957
+                }, 
+                {
+                    "accuracy": 87.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666103, 
+                    "longitude": 26.909604, 
+                    "seconds_offset_from_start": 958
+                }, 
+                {
+                    "accuracy": 74.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661122, 
+                    "longitude": 26.910774, 
+                    "seconds_offset_from_start": 959
+                }, 
+                {
+                    "accuracy": 67.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665655, 
+                    "longitude": 26.903287, 
+                    "seconds_offset_from_start": 960
+                }, 
+                {
+                    "accuracy": 79.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663742, 
+                    "longitude": 26.90961, 
+                    "seconds_offset_from_start": 961
+                }, 
+                {
+                    "accuracy": 91.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662911, 
+                    "longitude": 26.909528, 
+                    "seconds_offset_from_start": 962
+                }, 
+                {
+                    "accuracy": 61.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666497, 
+                    "longitude": 26.903867, 
+                    "seconds_offset_from_start": 963
+                }, 
+                {
+                    "accuracy": 93.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664486, 
+                    "longitude": 26.907291, 
+                    "seconds_offset_from_start": 964
+                }, 
+                {
+                    "accuracy": 60.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663392, 
+                    "longitude": 26.904131, 
+                    "seconds_offset_from_start": 965
+                }, 
+                {
+                    "accuracy": 76.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660269, 
+                    "longitude": 26.904369, 
+                    "seconds_offset_from_start": 966
+                }, 
+                {
+                    "accuracy": 79.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662632, 
+                    "longitude": 26.908893, 
+                    "seconds_offset_from_start": 967
+                }, 
+                {
+                    "accuracy": 69.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661823, 
+                    "longitude": 26.90447, 
+                    "seconds_offset_from_start": 968
+                }, 
+                {
+                    "accuracy": 76.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662328, 
+                    "longitude": 26.911111, 
+                    "seconds_offset_from_start": 969
+                }, 
+                {
+                    "accuracy": 98.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664575, 
+                    "longitude": 26.90838, 
+                    "seconds_offset_from_start": 970
+                }, 
+                {
+                    "accuracy": 64.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660298, 
+                    "longitude": 26.909432, 
+                    "seconds_offset_from_start": 971
+                }, 
+                {
+                    "accuracy": 68.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661973, 
+                    "longitude": 26.906582, 
+                    "seconds_offset_from_start": 972
+                }, 
+                {
+                    "accuracy": 72.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664109, 
+                    "longitude": 26.906129, 
+                    "seconds_offset_from_start": 973
+                }, 
+                {
+                    "accuracy": 73.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665382, 
+                    "longitude": 26.907269, 
+                    "seconds_offset_from_start": 974
+                }, 
+                {
+                    "accuracy": 96.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668584, 
+                    "longitude": 26.910626, 
+                    "seconds_offset_from_start": 975
+                }, 
+                {
+                    "accuracy": 79.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663222, 
+                    "longitude": 26.910391, 
+                    "seconds_offset_from_start": 976
+                }, 
+                {
+                    "accuracy": 80.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666232, 
+                    "longitude": 26.902513, 
+                    "seconds_offset_from_start": 977
+                }, 
+                {
+                    "accuracy": 73.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665497, 
+                    "longitude": 26.908944, 
+                    "seconds_offset_from_start": 978
+                }, 
+                {
+                    "accuracy": 62.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66458, 
+                    "longitude": 26.910962, 
+                    "seconds_offset_from_start": 979
+                }, 
+                {
+                    "accuracy": 63.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667651, 
+                    "longitude": 26.904929, 
+                    "seconds_offset_from_start": 980
+                }, 
+                {
+                    "accuracy": 97.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668599, 
+                    "longitude": 26.903522, 
+                    "seconds_offset_from_start": 981
+                }, 
+                {
+                    "accuracy": 84.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660061, 
+                    "longitude": 26.908722, 
+                    "seconds_offset_from_start": 982
+                }, 
+                {
+                    "accuracy": 99.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669052, 
+                    "longitude": 26.904289, 
+                    "seconds_offset_from_start": 983
+                }, 
+                {
+                    "accuracy": 94.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668736, 
+                    "longitude": 26.90529, 
+                    "seconds_offset_from_start": 984
+                }, 
+                {
+                    "accuracy": 96.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667118, 
+                    "longitude": 26.912171, 
+                    "seconds_offset_from_start": 985
+                }, 
+                {
+                    "accuracy": 99.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.6681, 
+                    "longitude": 26.910499, 
+                    "seconds_offset_from_start": 986
+                }, 
+                {
+                    "accuracy": 73.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661536, 
+                    "longitude": 26.907183, 
+                    "seconds_offset_from_start": 987
+                }, 
+                {
+                    "accuracy": 100.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665838, 
+                    "longitude": 26.903715, 
+                    "seconds_offset_from_start": 988
+                }, 
+                {
+                    "accuracy": 80.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665913, 
+                    "longitude": 26.906673, 
+                    "seconds_offset_from_start": 989
+                }, 
+                {
+                    "accuracy": 71.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668977, 
+                    "longitude": 26.911256, 
+                    "seconds_offset_from_start": 990
+                }, 
+                {
+                    "accuracy": 60.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664677, 
+                    "longitude": 26.905326, 
+                    "seconds_offset_from_start": 991
+                }, 
+                {
+                    "accuracy": 88.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.6672, 
+                    "longitude": 26.908836, 
+                    "seconds_offset_from_start": 992
+                }, 
+                {
+                    "accuracy": 90.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665567, 
+                    "longitude": 26.904769, 
+                    "seconds_offset_from_start": 993
+                }, 
+                {
+                    "accuracy": 93.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667967, 
+                    "longitude": 26.911096, 
+                    "seconds_offset_from_start": 994
+                }, 
+                {
+                    "accuracy": 99.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668206, 
+                    "longitude": 26.90547, 
+                    "seconds_offset_from_start": 995
+                }, 
+                {
+                    "accuracy": 63.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663985, 
+                    "longitude": 26.903988, 
+                    "seconds_offset_from_start": 996
+                }, 
+                {
+                    "accuracy": 67.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669038, 
+                    "longitude": 26.904945, 
+                    "seconds_offset_from_start": 997
+                }, 
+                {
+                    "accuracy": 99.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666599, 
+                    "longitude": 26.904447, 
+                    "seconds_offset_from_start": 998
+                }, 
+                {
+                    "accuracy": 83.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667519, 
+                    "longitude": 26.910436, 
+                    "seconds_offset_from_start": 999
+                }, 
+                {
+                    "accuracy": 100.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662547, 
+                    "longitude": 26.904664, 
+                    "seconds_offset_from_start": 1000
+                }, 
+                {
+                    "accuracy": 62.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667751, 
+                    "longitude": 26.906512, 
+                    "seconds_offset_from_start": 1001
+                }, 
+                {
+                    "accuracy": 73.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660769, 
+                    "longitude": 26.907728, 
+                    "seconds_offset_from_start": 1002
+                }, 
+                {
+                    "accuracy": 70.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660834, 
+                    "longitude": 26.911616, 
+                    "seconds_offset_from_start": 1003
+                }, 
+                {
+                    "accuracy": 70.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66412, 
+                    "longitude": 26.906246, 
+                    "seconds_offset_from_start": 1004
+                }, 
+                {
+                    "accuracy": 78.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660751, 
+                    "longitude": 26.904701, 
+                    "seconds_offset_from_start": 1005
+                }, 
+                {
+                    "accuracy": 78.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667929, 
+                    "longitude": 26.9094, 
+                    "seconds_offset_from_start": 1006
+                }, 
+                {
+                    "accuracy": 97.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661287, 
+                    "longitude": 26.904745, 
+                    "seconds_offset_from_start": 1007
+                }, 
+                {
+                    "accuracy": 62.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666663, 
+                    "longitude": 26.911848, 
+                    "seconds_offset_from_start": 1008
+                }, 
+                {
+                    "accuracy": 61.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668392, 
+                    "longitude": 26.910727, 
+                    "seconds_offset_from_start": 1009
+                }, 
+                {
+                    "accuracy": 65.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66447, 
+                    "longitude": 26.903864, 
+                    "seconds_offset_from_start": 1010
+                }, 
+                {
+                    "accuracy": 92.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667465, 
+                    "longitude": 26.904348, 
+                    "seconds_offset_from_start": 1011
+                }, 
+                {
+                    "accuracy": 75.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665299, 
+                    "longitude": 26.908779, 
+                    "seconds_offset_from_start": 1012
+                }, 
+                {
+                    "accuracy": 66.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663883, 
+                    "longitude": 26.90508, 
+                    "seconds_offset_from_start": 1013
+                }, 
+                {
+                    "accuracy": 89.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66277, 
+                    "longitude": 26.911014, 
+                    "seconds_offset_from_start": 1014
+                }, 
+                {
+                    "accuracy": 60.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668555, 
+                    "longitude": 26.902966, 
+                    "seconds_offset_from_start": 1015
+                }, 
+                {
+                    "accuracy": 90.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665829, 
+                    "longitude": 26.907433, 
+                    "seconds_offset_from_start": 1016
+                }, 
+                {
+                    "accuracy": 76.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664012, 
+                    "longitude": 26.912367, 
+                    "seconds_offset_from_start": 1017
+                }, 
+                {
+                    "accuracy": 93.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.6628, 
+                    "longitude": 26.911412, 
+                    "seconds_offset_from_start": 1018
+                }, 
+                {
+                    "accuracy": 78.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668642, 
+                    "longitude": 26.908542, 
+                    "seconds_offset_from_start": 1019
+                }, 
+                {
+                    "accuracy": 97.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662711, 
+                    "longitude": 26.910449, 
+                    "seconds_offset_from_start": 1020
+                }, 
+                {
+                    "accuracy": 78.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669334, 
+                    "longitude": 26.909868, 
+                    "seconds_offset_from_start": 1021
+                }, 
+                {
+                    "accuracy": 63.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664246, 
+                    "longitude": 26.910979, 
+                    "seconds_offset_from_start": 1022
+                }, 
+                {
+                    "accuracy": 60.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665156, 
+                    "longitude": 26.909772, 
+                    "seconds_offset_from_start": 1023
+                }, 
+                {
+                    "accuracy": 95.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665911, 
+                    "longitude": 26.911411, 
+                    "seconds_offset_from_start": 1024
+                }, 
+                {
+                    "accuracy": 73.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669381, 
+                    "longitude": 26.911286, 
+                    "seconds_offset_from_start": 1025
+                }, 
+                {
+                    "accuracy": 61.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668687, 
+                    "longitude": 26.906042, 
+                    "seconds_offset_from_start": 1026
+                }, 
+                {
+                    "accuracy": 72.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669172, 
+                    "longitude": 26.911063, 
+                    "seconds_offset_from_start": 1027
+                }, 
+                {
+                    "accuracy": 95.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668648, 
+                    "longitude": 26.903515, 
+                    "seconds_offset_from_start": 1028
+                }, 
+                {
+                    "accuracy": 66.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668541, 
+                    "longitude": 26.906015, 
+                    "seconds_offset_from_start": 1029
+                }, 
+                {
+                    "accuracy": 85.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663672, 
+                    "longitude": 26.911672, 
+                    "seconds_offset_from_start": 1030
+                }, 
+                {
+                    "accuracy": 76.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666027, 
+                    "longitude": 26.904827, 
+                    "seconds_offset_from_start": 1031
+                }, 
+                {
+                    "accuracy": 96.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664725, 
+                    "longitude": 26.905285, 
+                    "seconds_offset_from_start": 1032
+                }, 
+                {
+                    "accuracy": 60.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662997, 
+                    "longitude": 26.907505, 
+                    "seconds_offset_from_start": 1033
+                }, 
+                {
+                    "accuracy": 77.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666657, 
+                    "longitude": 26.908489, 
+                    "seconds_offset_from_start": 1034
+                }, 
+                {
+                    "accuracy": 89.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664262, 
+                    "longitude": 26.909474, 
+                    "seconds_offset_from_start": 1035
+                }, 
+                {
+                    "accuracy": 66.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664973, 
+                    "longitude": 26.910936, 
+                    "seconds_offset_from_start": 1036
+                }, 
+                {
+                    "accuracy": 89.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663622, 
+                    "longitude": 26.908499, 
+                    "seconds_offset_from_start": 1037
+                }, 
+                {
+                    "accuracy": 60.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666374, 
+                    "longitude": 26.9029, 
+                    "seconds_offset_from_start": 1038
+                }, 
+                {
+                    "accuracy": 97.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669915, 
+                    "longitude": 26.910996, 
+                    "seconds_offset_from_start": 1039
+                }, 
+                {
+                    "accuracy": 97.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66544, 
+                    "longitude": 26.90341, 
+                    "seconds_offset_from_start": 1040
+                }, 
+                {
+                    "accuracy": 91.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66475, 
+                    "longitude": 26.903993, 
+                    "seconds_offset_from_start": 1041
+                }, 
+                {
+                    "accuracy": 64.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660356, 
+                    "longitude": 26.905139, 
+                    "seconds_offset_from_start": 1042
+                }, 
+                {
+                    "accuracy": 98.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66922, 
+                    "longitude": 26.905283, 
+                    "seconds_offset_from_start": 1043
+                }, 
+                {
+                    "accuracy": 92.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663438, 
+                    "longitude": 26.912251, 
+                    "seconds_offset_from_start": 1044
+                }, 
+                {
+                    "accuracy": 88.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665286, 
+                    "longitude": 26.907194, 
+                    "seconds_offset_from_start": 1045
+                }, 
+                {
+                    "accuracy": 75.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.6698, 
+                    "longitude": 26.906649, 
+                    "seconds_offset_from_start": 1046
+                }, 
+                {
+                    "accuracy": 66.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66649, 
+                    "longitude": 26.910851, 
+                    "seconds_offset_from_start": 1047
+                }, 
+                {
+                    "accuracy": 77.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665985, 
+                    "longitude": 26.910805, 
+                    "seconds_offset_from_start": 1048
+                }, 
+                {
+                    "accuracy": 86.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669405, 
+                    "longitude": 26.909236, 
+                    "seconds_offset_from_start": 1049
+                }, 
+                {
+                    "accuracy": 94.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668618, 
+                    "longitude": 26.905901, 
+                    "seconds_offset_from_start": 1050
+                }, 
+                {
+                    "accuracy": 64.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662305, 
+                    "longitude": 26.904547, 
+                    "seconds_offset_from_start": 1051
+                }, 
+                {
+                    "accuracy": 65.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664767, 
+                    "longitude": 26.909001, 
+                    "seconds_offset_from_start": 1052
+                }, 
+                {
+                    "accuracy": 91.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663632, 
+                    "longitude": 26.906659, 
+                    "seconds_offset_from_start": 1053
+                }, 
+                {
+                    "accuracy": 69.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665759, 
+                    "longitude": 26.906392, 
+                    "seconds_offset_from_start": 1054
+                }, 
+                {
+                    "accuracy": 61.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665593, 
+                    "longitude": 26.910199, 
+                    "seconds_offset_from_start": 1055
+                }, 
+                {
+                    "accuracy": 97.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66684, 
+                    "longitude": 26.907338, 
+                    "seconds_offset_from_start": 1056
+                }, 
+                {
+                    "accuracy": 98.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66798, 
+                    "longitude": 26.907282, 
+                    "seconds_offset_from_start": 1057
+                }, 
+                {
+                    "accuracy": 88.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665052, 
+                    "longitude": 26.906605, 
+                    "seconds_offset_from_start": 1058
+                }, 
+                {
+                    "accuracy": 95.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667755, 
+                    "longitude": 26.90581, 
+                    "seconds_offset_from_start": 1059
+                }, 
+                {
+                    "accuracy": 93.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665734, 
+                    "longitude": 26.910104, 
+                    "seconds_offset_from_start": 1060
+                }, 
+                {
+                    "accuracy": 80.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667599, 
+                    "longitude": 26.907212, 
+                    "seconds_offset_from_start": 1061
+                }, 
+                {
+                    "accuracy": 96.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665276, 
+                    "longitude": 26.904764, 
+                    "seconds_offset_from_start": 1062
+                }, 
+                {
+                    "accuracy": 79.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663851, 
+                    "longitude": 26.908034, 
+                    "seconds_offset_from_start": 1063
+                }, 
+                {
+                    "accuracy": 91.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66457, 
+                    "longitude": 26.910201, 
+                    "seconds_offset_from_start": 1064
+                }, 
+                {
+                    "accuracy": 89.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666805, 
+                    "longitude": 26.910443, 
+                    "seconds_offset_from_start": 1065
+                }, 
+                {
+                    "accuracy": 90.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661509, 
+                    "longitude": 26.91202, 
+                    "seconds_offset_from_start": 1066
+                }, 
+                {
+                    "accuracy": 69.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669549, 
+                    "longitude": 26.904018, 
+                    "seconds_offset_from_start": 1067
+                }, 
+                {
+                    "accuracy": 60.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663309, 
+                    "longitude": 26.90585, 
+                    "seconds_offset_from_start": 1068
+                }, 
+                {
+                    "accuracy": 97.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669171, 
+                    "longitude": 26.904387, 
+                    "seconds_offset_from_start": 1069
+                }, 
+                {
+                    "accuracy": 61.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662712, 
+                    "longitude": 26.907021, 
+                    "seconds_offset_from_start": 1070
+                }, 
+                {
+                    "accuracy": 88.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667712, 
+                    "longitude": 26.908745, 
+                    "seconds_offset_from_start": 1071
+                }, 
+                {
+                    "accuracy": 93.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669278, 
+                    "longitude": 26.904071, 
+                    "seconds_offset_from_start": 1072
+                }, 
+                {
+                    "accuracy": 60.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661447, 
+                    "longitude": 26.903622, 
+                    "seconds_offset_from_start": 1073
+                }, 
+                {
+                    "accuracy": 100.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661323, 
+                    "longitude": 26.908591, 
+                    "seconds_offset_from_start": 1074
+                }, 
+                {
+                    "accuracy": 98.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662495, 
+                    "longitude": 26.911638, 
+                    "seconds_offset_from_start": 1075
+                }, 
+                {
+                    "accuracy": 93.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660495, 
+                    "longitude": 26.909462, 
+                    "seconds_offset_from_start": 1076
+                }, 
+                {
+                    "accuracy": 85.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665656, 
+                    "longitude": 26.909571, 
+                    "seconds_offset_from_start": 1077
+                }, 
+                {
+                    "accuracy": 71.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662478, 
+                    "longitude": 26.903561, 
+                    "seconds_offset_from_start": 1078
+                }, 
+                {
+                    "accuracy": 62.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663313, 
+                    "longitude": 26.909212, 
+                    "seconds_offset_from_start": 1079
+                }, 
+                {
+                    "accuracy": 75.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665059, 
+                    "longitude": 26.910988, 
+                    "seconds_offset_from_start": 1080
+                }, 
+                {
+                    "accuracy": 99.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665396, 
+                    "longitude": 26.904024, 
+                    "seconds_offset_from_start": 1081
+                }, 
+                {
+                    "accuracy": 74.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665341, 
+                    "longitude": 26.906846, 
+                    "seconds_offset_from_start": 1082
+                }, 
+                {
+                    "accuracy": 90.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669591, 
+                    "longitude": 26.903045, 
+                    "seconds_offset_from_start": 1083
+                }, 
+                {
+                    "accuracy": 72.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661415, 
+                    "longitude": 26.910113, 
+                    "seconds_offset_from_start": 1084
+                }, 
+                {
+                    "accuracy": 85.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66537, 
+                    "longitude": 26.907741, 
+                    "seconds_offset_from_start": 1085
+                }, 
+                {
+                    "accuracy": 92.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663117, 
+                    "longitude": 26.910837, 
+                    "seconds_offset_from_start": 1086
+                }, 
+                {
+                    "accuracy": 70.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668373, 
+                    "longitude": 26.910124, 
+                    "seconds_offset_from_start": 1087
+                }, 
+                {
+                    "accuracy": 60.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661725, 
+                    "longitude": 26.905036, 
+                    "seconds_offset_from_start": 1088
+                }, 
+                {
+                    "accuracy": 65.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669399, 
+                    "longitude": 26.912216, 
+                    "seconds_offset_from_start": 1089
+                }, 
+                {
+                    "accuracy": 81.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661572, 
+                    "longitude": 26.906338, 
+                    "seconds_offset_from_start": 1090
+                }, 
+                {
+                    "accuracy": 62.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660664, 
+                    "longitude": 26.90256, 
+                    "seconds_offset_from_start": 1091
+                }, 
+                {
+                    "accuracy": 84.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668054, 
+                    "longitude": 26.903041, 
+                    "seconds_offset_from_start": 1092
+                }, 
+                {
+                    "accuracy": 95.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662591, 
+                    "longitude": 26.909839, 
+                    "seconds_offset_from_start": 1093
+                }, 
+                {
+                    "accuracy": 95.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661512, 
+                    "longitude": 26.903002, 
+                    "seconds_offset_from_start": 1094
+                }, 
+                {
+                    "accuracy": 94.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662677, 
+                    "longitude": 26.903213, 
+                    "seconds_offset_from_start": 1095
+                }, 
+                {
+                    "accuracy": 85.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665874, 
+                    "longitude": 26.909394, 
+                    "seconds_offset_from_start": 1096
+                }, 
+                {
+                    "accuracy": 86.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662956, 
+                    "longitude": 26.911612, 
+                    "seconds_offset_from_start": 1097
+                }, 
+                {
+                    "accuracy": 84.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660599, 
+                    "longitude": 26.907621, 
+                    "seconds_offset_from_start": 1098
+                }, 
+                {
+                    "accuracy": 81.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669373, 
+                    "longitude": 26.90403, 
+                    "seconds_offset_from_start": 1099
+                }, 
+                {
+                    "accuracy": 97.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662312, 
+                    "longitude": 26.902576, 
+                    "seconds_offset_from_start": 1100
+                }, 
+                {
+                    "accuracy": 63.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663249, 
+                    "longitude": 26.906394, 
+                    "seconds_offset_from_start": 1101
+                }, 
+                {
+                    "accuracy": 75.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664772, 
+                    "longitude": 26.903754, 
+                    "seconds_offset_from_start": 1102
+                }, 
+                {
+                    "accuracy": 62.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665986, 
+                    "longitude": 26.91249, 
+                    "seconds_offset_from_start": 1103
+                }, 
+                {
+                    "accuracy": 68.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662798, 
+                    "longitude": 26.910952, 
+                    "seconds_offset_from_start": 1104
+                }, 
+                {
+                    "accuracy": 71.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66695, 
+                    "longitude": 26.904116, 
+                    "seconds_offset_from_start": 1105
+                }, 
+                {
+                    "accuracy": 95.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667121, 
+                    "longitude": 26.906973, 
+                    "seconds_offset_from_start": 1106
+                }, 
+                {
+                    "accuracy": 100.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664678, 
+                    "longitude": 26.907537, 
+                    "seconds_offset_from_start": 1107
+                }, 
+                {
+                    "accuracy": 87.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660874, 
+                    "longitude": 26.905998, 
+                    "seconds_offset_from_start": 1108
+                }, 
+                {
+                    "accuracy": 60.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663032, 
+                    "longitude": 26.902671, 
+                    "seconds_offset_from_start": 1109
+                }, 
+                {
+                    "accuracy": 93.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660128, 
+                    "longitude": 26.905898, 
+                    "seconds_offset_from_start": 1110
+                }, 
+                {
+                    "accuracy": 98.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665442, 
+                    "longitude": 26.907371, 
+                    "seconds_offset_from_start": 1111
+                }, 
+                {
+                    "accuracy": 84.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663742, 
+                    "longitude": 26.912359, 
+                    "seconds_offset_from_start": 1112
+                }, 
+                {
+                    "accuracy": 89.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664443, 
+                    "longitude": 26.911651, 
+                    "seconds_offset_from_start": 1113
+                }, 
+                {
+                    "accuracy": 70.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666011, 
+                    "longitude": 26.903986, 
+                    "seconds_offset_from_start": 1114
+                }, 
+                {
+                    "accuracy": 84.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662867, 
+                    "longitude": 26.909489, 
+                    "seconds_offset_from_start": 1115
+                }, 
+                {
+                    "accuracy": 71.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660691, 
+                    "longitude": 26.903703, 
+                    "seconds_offset_from_start": 1116
+                }, 
+                {
+                    "accuracy": 69.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662954, 
+                    "longitude": 26.907955, 
+                    "seconds_offset_from_start": 1117
+                }, 
+                {
+                    "accuracy": 99.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.6681, 
+                    "longitude": 26.906271, 
+                    "seconds_offset_from_start": 1118
+                }, 
+                {
+                    "accuracy": 86.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665437, 
+                    "longitude": 26.912455, 
+                    "seconds_offset_from_start": 1119
+                }, 
+                {
+                    "accuracy": 70.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666903, 
+                    "longitude": 26.904597, 
+                    "seconds_offset_from_start": 1120
+                }, 
+                {
+                    "accuracy": 66.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665477, 
+                    "longitude": 26.902776, 
+                    "seconds_offset_from_start": 1121
+                }, 
+                {
+                    "accuracy": 61.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664885, 
+                    "longitude": 26.906913, 
+                    "seconds_offset_from_start": 1122
+                }, 
+                {
+                    "accuracy": 62.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665875, 
+                    "longitude": 26.90907, 
+                    "seconds_offset_from_start": 1123
+                }, 
+                {
+                    "accuracy": 89.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667384, 
+                    "longitude": 26.907923, 
+                    "seconds_offset_from_start": 1124
+                }, 
+                {
+                    "accuracy": 98.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668228, 
+                    "longitude": 26.906005, 
+                    "seconds_offset_from_start": 1125
+                }, 
+                {
+                    "accuracy": 70.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667099, 
+                    "longitude": 26.908161, 
+                    "seconds_offset_from_start": 1126
+                }, 
+                {
+                    "accuracy": 68.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661757, 
+                    "longitude": 26.906117, 
+                    "seconds_offset_from_start": 1127
+                }, 
+                {
+                    "accuracy": 86.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660558, 
+                    "longitude": 26.903048, 
+                    "seconds_offset_from_start": 1128
+                }, 
+                {
+                    "accuracy": 82.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66576, 
+                    "longitude": 26.903859, 
+                    "seconds_offset_from_start": 1129
+                }, 
+                {
+                    "accuracy": 82.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660236, 
+                    "longitude": 26.904343, 
+                    "seconds_offset_from_start": 1130
+                }, 
+                {
+                    "accuracy": 93.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668867, 
+                    "longitude": 26.909687, 
+                    "seconds_offset_from_start": 1131
+                }, 
+                {
+                    "accuracy": 92.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667976, 
+                    "longitude": 26.909203, 
+                    "seconds_offset_from_start": 1132
+                }, 
+                {
+                    "accuracy": 93.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668838, 
+                    "longitude": 26.911482, 
+                    "seconds_offset_from_start": 1133
+                }, 
+                {
+                    "accuracy": 61.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667632, 
+                    "longitude": 26.904533, 
+                    "seconds_offset_from_start": 1134
+                }, 
+                {
+                    "accuracy": 67.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66085, 
+                    "longitude": 26.911366, 
+                    "seconds_offset_from_start": 1135
+                }, 
+                {
+                    "accuracy": 75.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662389, 
+                    "longitude": 26.910674, 
+                    "seconds_offset_from_start": 1136
+                }, 
+                {
+                    "accuracy": 73.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669393, 
+                    "longitude": 26.902795, 
+                    "seconds_offset_from_start": 1137
+                }, 
+                {
+                    "accuracy": 94.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669155, 
+                    "longitude": 26.903577, 
+                    "seconds_offset_from_start": 1138
+                }, 
+                {
+                    "accuracy": 70.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665204, 
+                    "longitude": 26.911375, 
+                    "seconds_offset_from_start": 1139
+                }
+            ]
+        },
+        {
+            "segment_id": "67d0c9cd49c64c62855d81d999ef68c2",
+            "is_gap": false,
+            "coordinates": [
+                {
+                    "accuracy": 69.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660646, 
+                    "longitude": 26.907692, 
+                    "seconds_offset_from_start": 1140
+                }, 
+                {
+                    "accuracy": 89.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663093, 
+                    "longitude": 26.9065, 
+                    "seconds_offset_from_start": 1141
+                }, 
+                {
+                    "accuracy": 69.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661435, 
+                    "longitude": 26.905552, 
+                    "seconds_offset_from_start": 1142
+                }, 
+                {
+                    "accuracy": 70.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66553, 
+                    "longitude": 26.91138, 
+                    "seconds_offset_from_start": 1143
+                }, 
+                {
+                    "accuracy": 69.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669482, 
+                    "longitude": 26.910579, 
+                    "seconds_offset_from_start": 1144
+                }, 
+                {
+                    "accuracy": 65.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665792, 
+                    "longitude": 26.912384, 
+                    "seconds_offset_from_start": 1145
+                }, 
+                {
+                    "accuracy": 83.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668462, 
+                    "longitude": 26.907601, 
+                    "seconds_offset_from_start": 1146
+                }, 
+                {
+                    "accuracy": 94.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664748, 
+                    "longitude": 26.908267, 
+                    "seconds_offset_from_start": 1147
+                }, 
+                {
+                    "accuracy": 97.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663093, 
+                    "longitude": 26.903194, 
+                    "seconds_offset_from_start": 1148
+                }, 
+                {
+                    "accuracy": 83.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669684, 
+                    "longitude": 26.908915, 
+                    "seconds_offset_from_start": 1149
+                }, 
+                {
+                    "accuracy": 98.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668162, 
+                    "longitude": 26.911361, 
+                    "seconds_offset_from_start": 1150
+                }, 
+                {
+                    "accuracy": 79.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663468, 
+                    "longitude": 26.907293, 
+                    "seconds_offset_from_start": 1151
+                }, 
+                {
+                    "accuracy": 78.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661204, 
+                    "longitude": 26.909172, 
+                    "seconds_offset_from_start": 1152
+                }, 
+                {
+                    "accuracy": 78.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66054, 
+                    "longitude": 26.905556, 
+                    "seconds_offset_from_start": 1153
+                }, 
+                {
+                    "accuracy": 75.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661259, 
+                    "longitude": 26.912293, 
+                    "seconds_offset_from_start": 1154
+                }, 
+                {
+                    "accuracy": 91.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669167, 
+                    "longitude": 26.90929, 
+                    "seconds_offset_from_start": 1155
+                }, 
+                {
+                    "accuracy": 80.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66999, 
+                    "longitude": 26.910638, 
+                    "seconds_offset_from_start": 1156
+                }, 
+                {
+                    "accuracy": 89.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668997, 
+                    "longitude": 26.911775, 
+                    "seconds_offset_from_start": 1157
+                }, 
+                {
+                    "accuracy": 73.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667323, 
+                    "longitude": 26.907151, 
+                    "seconds_offset_from_start": 1158
+                }, 
+                {
+                    "accuracy": 62.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66731, 
+                    "longitude": 26.910539, 
+                    "seconds_offset_from_start": 1159
+                }, 
+                {
+                    "accuracy": 94.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668669, 
+                    "longitude": 26.906232, 
+                    "seconds_offset_from_start": 1160
+                }, 
+                {
+                    "accuracy": 98.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664566, 
+                    "longitude": 26.906129, 
+                    "seconds_offset_from_start": 1161
+                }, 
+                {
+                    "accuracy": 87.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66015, 
+                    "longitude": 26.902928, 
+                    "seconds_offset_from_start": 1162
+                }, 
+                {
+                    "accuracy": 75.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669193, 
+                    "longitude": 26.907799, 
+                    "seconds_offset_from_start": 1163
+                }, 
+                {
+                    "accuracy": 97.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667813, 
+                    "longitude": 26.909408, 
+                    "seconds_offset_from_start": 1164
+                }, 
+                {
+                    "accuracy": 67.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667502, 
+                    "longitude": 26.904141, 
+                    "seconds_offset_from_start": 1165
+                }, 
+                {
+                    "accuracy": 72.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661921, 
+                    "longitude": 26.904207, 
+                    "seconds_offset_from_start": 1166
+                }, 
+                {
+                    "accuracy": 86.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665441, 
+                    "longitude": 26.907676, 
+                    "seconds_offset_from_start": 1167
+                }, 
+                {
+                    "accuracy": 79.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.668423, 
+                    "longitude": 26.909072, 
+                    "seconds_offset_from_start": 1168
+                }, 
+                {
+                    "accuracy": 80.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66771, 
+                    "longitude": 26.907111, 
+                    "seconds_offset_from_start": 1169
+                }, 
+                {
+                    "accuracy": 91.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661186, 
+                    "longitude": 26.902623, 
+                    "seconds_offset_from_start": 1170
+                }, 
+                {
+                    "accuracy": 60.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665468, 
+                    "longitude": 26.905439, 
+                    "seconds_offset_from_start": 1171
+                }, 
+                {
+                    "accuracy": 73.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662773, 
+                    "longitude": 26.908756, 
+                    "seconds_offset_from_start": 1172
+                }, 
+                {
+                    "accuracy": 67.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664377, 
+                    "longitude": 26.906549, 
+                    "seconds_offset_from_start": 1173
+                }, 
+                {
+                    "accuracy": 66.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665438, 
+                    "longitude": 26.90548, 
+                    "seconds_offset_from_start": 1174
+                }, 
+                {
+                    "accuracy": 80.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664251, 
+                    "longitude": 26.911653, 
+                    "seconds_offset_from_start": 1175
+                }, 
+                {
+                    "accuracy": 73.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66206, 
+                    "longitude": 26.905747, 
+                    "seconds_offset_from_start": 1176
+                }, 
+                {
+                    "accuracy": 61.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.66292, 
+                    "longitude": 26.904854, 
+                    "seconds_offset_from_start": 1177
+                }, 
+                {
+                    "accuracy": 64.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.661588, 
+                    "longitude": 26.907484, 
+                    "seconds_offset_from_start": 1178
+                }, 
+                {
+                    "accuracy": 86.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662913, 
+                    "longitude": 26.906582, 
+                    "seconds_offset_from_start": 1179
+                }, 
+                {
+                    "accuracy": 66.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665608, 
+                    "longitude": 26.907988, 
+                    "seconds_offset_from_start": 1180
+                }, 
+                {
+                    "accuracy": 68.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666461, 
+                    "longitude": 26.909715, 
+                    "seconds_offset_from_start": 1181
+                }, 
+                {
+                    "accuracy": 98.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665168, 
+                    "longitude": 26.906849, 
+                    "seconds_offset_from_start": 1182
+                }, 
+                {
+                    "accuracy": 71.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.664429, 
+                    "longitude": 26.905237, 
+                    "seconds_offset_from_start": 1183
+                }, 
+                {
+                    "accuracy": 90.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666981, 
+                    "longitude": 26.909903, 
+                    "seconds_offset_from_start": 1184
+                }, 
+                {
+                    "accuracy": 84.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662386, 
+                    "longitude": 26.908507, 
+                    "seconds_offset_from_start": 1185
+                }, 
+                {
+                    "accuracy": 95.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665397, 
+                    "longitude": 26.903688, 
+                    "seconds_offset_from_start": 1186
+                }, 
+                {
+                    "accuracy": 66.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669279, 
+                    "longitude": 26.903507, 
+                    "seconds_offset_from_start": 1187
+                }, 
+                {
+                    "accuracy": 87.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669292, 
+                    "longitude": 26.909757, 
+                    "seconds_offset_from_start": 1188
+                }, 
+                {
+                    "accuracy": 100.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667728, 
+                    "longitude": 26.907484, 
+                    "seconds_offset_from_start": 1189
+                }, 
+                {
+                    "accuracy": 79.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.662361, 
+                    "longitude": 26.911272, 
+                    "seconds_offset_from_start": 1190
+                }, 
+                {
+                    "accuracy": 72.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.669344, 
+                    "longitude": 26.907417, 
+                    "seconds_offset_from_start": 1191
+                }, 
+                {
+                    "accuracy": 66.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666708, 
+                    "longitude": 26.906434, 
+                    "seconds_offset_from_start": 1192
+                }, 
+                {
+                    "accuracy": 71.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666566, 
+                    "longitude": 26.906565, 
+                    "seconds_offset_from_start": 1193
+                }, 
+                {
+                    "accuracy": 62.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.665994, 
+                    "longitude": 26.902777, 
+                    "seconds_offset_from_start": 1194
+                }, 
+                {
+                    "accuracy": 62.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.663412, 
+                    "longitude": 26.910815, 
+                    "seconds_offset_from_start": 1195
+                }, 
+                {
+                    "accuracy": 93.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.660199, 
+                    "longitude": 26.910859, 
+                    "seconds_offset_from_start": 1196
+                }, 
+                {
+                    "accuracy": 99.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.666908, 
+                    "longitude": 26.911402, 
+                    "seconds_offset_from_start": 1197
+                }, 
+                {
+                    "accuracy": 93.0, 
+                    "distance": 0.0, 
+                    "distance_display_unit": "mi", 
+                    "latitude": -71.667965, 
+                    "longitude": 26.91073, 
+                    "seconds_offset_from_start": 1198
+                }
+            ]
+        }
+    ],
+    "is_location_data_accurate": true,
     "splits_data": {
         "distance_marker_display_unit": "mi",
         "elevation_change_display_unit": "ft",

--- a/tests/tcx_test_helper.py
+++ b/tests/tcx_test_helper.py
@@ -79,3 +79,16 @@ def assertTcxTriggerMethodMatches(workoutSummary, tcx):
     actual = tcx[0][0][2][7].text 
     expected = "Manual"
     assert actual == expected
+
+def assertTcxPositionDataPresent(workoutSummary, tcx):
+    actualLat = tcx[0][0][2][9][1000][0][0].text
+    actualLon = tcx[0][0][2][9][1000][0][1].text
+    actualAltitude = tcx[0][0][2][9][1000][0][2].text
+
+    expectedLat = str(-71.662547)
+    expectedLon = str(26.904664)
+    expectedAltitude = str(40.2336)
+
+    assert actualLat == expectedLat
+    assert actualLon == expectedLon
+    assert actualAltitude == expectedAltitude

--- a/tests/test_tcx_builder.py
+++ b/tests/test_tcx_builder.py
@@ -233,6 +233,7 @@ class TestTcxBuilder:
         TCX.assertTcxMaxBikeCadenceMatches(workout_summary, tcx)
         TCX.assertTcxAvgWattsMatches(workout_summary, tcx)
         TCX.assertTcxMaxWattsMatches(workout_summary, tcx)
+        TCX.assertTcxPositionDataPresent(workout_summary, tcx)
 
     getDistanceMeters_testdata = [
         (10, "m", "10.0"),


### PR DESCRIPTION
Closes #35 

Summary of changes:

- Updates to tcx_builder.py
  - Flatten data from Peloton API to return a dict keyed on the second_offset_from_start
  - Add function to convert feet to meters if needed
  - Map data and add relevant TCX elements
- Updates to tests
   - Add randomized location_data to peloton_workoutsamples_running_outdoor
   - Add test in tcx_test_helper.py to check position data is present and correct
   - Plumb test into test_tcx_builder.py

E2E Tests:
- Converted updated outdoor run to TCX and uploaded to Strava - worked as expected
- Converted personal run to TCX and uploaded to Strava - verified that position/elevation data matches route I ran

 Test output:
```
$ pytest
=================================================================================== test session starts ====================================================================================
platform darwin -- Python 3.9.2, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /Users/[removed]/code/peloton-to-garmin/tests
plugins: mock-3.5.1
collected 29 items                                                                                                                                                                         

test_garminClient.py ........                                                                                                                                                        [ 27%]
test_peloton-to-garmin.py .                                                                                                                                                          [ 31%]
test_tcx_builder.py ....................                                                                                                                                             [100%]

==================================================================================== 29 passed in 0.99s ====================================================================================
```
