### PR TITLE
Create a GitHub Actions workflow to automatically sync Peloton to Garmin

### DIFF
--- a/.github/workflows/docker_latest.yml
+++ b/.github/workflows/docker_latest.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           push: true
           file: ./docker/Dockerfile.console
-          tags: philosowaffle/peloton-to-garmin:latest
+          tags: ${{ secrets.DOCKER_USERNAME }}/peloton-to-garmin:latest
           platforms: linux/arm64,linux/amd64
           build-args: VERSION=${{ env.BUILD_VERSION }}
           cache-from: type=local,src=/tmp/.buildx-cache

--- a/.github/workflows/docker_latest.yml
+++ b/.github/workflows/docker_latest.yml
@@ -117,7 +117,7 @@ jobs:
         with:
           push: true
           file: ./docker/Dockerfile.api
-          tags: philosowaffle/peloton-to-garmin:api-latest
+          tags: ${{ secrets.DOCKER_USERNAME }}/peloton-to-garmin:api-latest
           platforms: linux/arm64,linux/amd64
           build-args: VERSION=${{ env.BUILD_VERSION }}
           cache-from: type=local,src=/tmp/.buildx-cache
@@ -178,7 +178,7 @@ jobs:
         with:
           push: true
           file: ./docker/Dockerfile.webui
-          tags: philosowaffle/peloton-to-garmin:webui-latest
+          tags: ${{ secrets.DOCKER_USERNAME }}/peloton-to-garmin:webui-latest
           platforms: linux/arm64,linux/amd64
           build-args: VERSION=${{ env.BUILD_VERSION }}
           cache-from: type=local,src=/tmp/.buildx-cache

--- a/.github/workflows/sync_peloton_to_garmin.yml
+++ b/.github/workflows/sync_peloton_to_garmin.yml
@@ -47,7 +47,7 @@ jobs:
           },
           "Peloton": {
             "NumWorkoutsToDownload": ${{ github.event.inputs.workoutsToDownload || env.DEFAULT_WORKOUT_NUM }},
-            "ExcludeWorkoutTypes": [ "meditation" ],
+            "ExcludeWorkoutTypes": [ "cycling" ],
           },
           "Garmin": {
             "Upload": true,

--- a/.github/workflows/sync_peloton_to_garmin.yml
+++ b/.github/workflows/sync_peloton_to_garmin.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     # The type of runner that the job will run on
     container: 
-      image:  philosowaffle/peloton-to-garmin:latest
+      image:  dkuwahara/peloton-to-garmin:latest
     steps:
     - run: mkdir -p /app/output
     - name: Create device info file
@@ -47,7 +47,7 @@ jobs:
           },
           "Peloton": {
             "NumWorkoutsToDownload": ${{ github.event.inputs.workoutsToDownload || env.DEFAULT_WORKOUT_NUM }},
-            "ExcludeWorkoutTypes": [ "cycling" ],
+            "ExcludeWorkoutTypes": [ "meditation" ],
           },
           "Garmin": {
             "Upload": true,

--- a/.github/workflows/sync_peloton_to_garmin.yml
+++ b/.github/workflows/sync_peloton_to_garmin.yml
@@ -63,7 +63,7 @@ jobs:
             },
             "Serilog": {
               "Using": [ "Serilog.Sinks.Console"],
-              "MinimumLevel": "Information",
+              "MinimumLevel": "Debug",
               "WriteTo": [
                 { "Name": "Console" }
               ]

--- a/.github/workflows/sync_peloton_to_garmin.yml
+++ b/.github/workflows/sync_peloton_to_garmin.yml
@@ -1,0 +1,80 @@
+# This is a workflow that will automatically sync your Peloton rides with Garmin
+
+name: Sync workflow
+
+# Controls when the action will run.
+on:
+  workflow_dispatch:
+    inputs:
+      workoutsToDownload:
+        type: number
+        default: "5"
+  schedule:
+    - cron: 0 1 * * *
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    # The type of runner that the job will run on
+    container: 
+      image:  dkuwahara/peloton-to-garmin:latest
+    steps:
+    - run: mkdir -p /app/output
+    - name: Create device info file
+      run: |
+        cat <<EOT > /app/deviceInfo.xml
+        ${{secrets.DEVICE_INFO}}
+        EOT
+    - name: Create config file
+      env:
+        DEFAULT_WORKOUT_NUM: 5
+      run: |
+        cat <<EOT > /app/configuration.local.json 
+        {
+          "App": {
+            "OutputDirectory": "./output",
+            "EnablePolling": false,
+            "CloseWindowOnFinish": true
+          },
+          "Format": {
+            "Fit": true,
+            "Json": false,
+            "Tcx": false,
+            "SaveLocalCopy": false,
+            "IncludeTimeInHRZones": false,
+            "IncludeTimeInPowerZones": false,
+            "DeviceInfoPath": "./deviceInfo.xml"
+          },
+          "Peloton": {
+            "NumWorkoutsToDownload": ${{ github.event.inputs.workoutsToDownload || env.DEFAULT_WORKOUT_NUM }},
+            "ExcludeWorkoutTypes": [ "meditation" ],
+          },
+          "Garmin": {
+            "Upload": true,
+            "FormatToUpload": "fit",
+            "UploadStrategy": 2
+          },
+          "Observability": {
+            "Prometheus": {
+              "Enabled": false
+            },
+            "Jaeger": {
+              "Enabled": false
+            },
+            "Serilog": {
+              "Using": [ "Serilog.Sinks.Console"],
+              "MinimumLevel": "Information",
+              "WriteTo": [
+                { "Name": "Console" }
+              ]
+            }
+          }
+        }
+        EOT
+    - run: /app/PelotonToGarminConsole
+      working-directory: /app
+      env:
+        P2G_PELOTON__EMAIL: ${{ secrets.P2G_PELOTON__EMAIL }}
+        P2G_PELOTON__PASSWORD: ${{ secrets.P2G_PELOTON__PASSWORD }}
+        P2G_GARMIN__EMAIL: ${{ secrets.P2G_GARMIN__EMAIL }}
+        P2G_GARMIN__PASSWORD: ${{ secrets.P2G_GARMIN__PASSWORD }}

--- a/.github/workflows/sync_peloton_to_garmin.yml
+++ b/.github/workflows/sync_peloton_to_garmin.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     # The type of runner that the job will run on
     container: 
-      image:  dkuwahara/peloton-to-garmin:latest
+      image:  philosowaffle/peloton-to-garmin:latest
     steps:
     - run: mkdir -p /app/output
     - name: Create device info file

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Environmnet Variables
+title: Environment Variables
 parent: Configuration
 nav_order: 2
 ---

--- a/docs/install/github-action.md
+++ b/docs/install/github-action.md
@@ -1,0 +1,38 @@
+---
+layout: default
+title: Using the Github Action
+nav_order: 2
+has_children: false
+---
+
+# Github Actions
+
+A Github Actions workflow exists that can be used to automatically sync your rides on a schedule (by default once a day)
+
+## Getting started
+
+The easiest way to use the action is to simply create a fork of the repo using the `Fork` button. 
+
+## Secrets
+
+Once you've created your fork, you'll need to set a number of secrets in your repository.
+
+You can set secrets by clicking the `Settings` tab in your fork. Then, on the side nav, select `Secrets` and then `Actions`.
+
+From this point on you can add secrets by clicking the `New repository secret` button at the top right.
+
+| Secret Name      | Value       |
+|:-----------------|:------------------|
+| `P2G_PELOTON__EMAIL` | The email address you use to login to Peloton |
+| `P2G_PELOTON__PASSWORD` | The password that you use to login to Peloton  |
+| ` P2G_GARMIN__EMAIL` | The email address that you use to login to Garmin      |
+| `P2G_GARMIN__PASSWORD` |The password that you use to log into Garmin |
+| `DEVICE_INFO` | The contents of the deviceInfo.xml that you want to use for the sync |
+
+## Starting the workflow
+
+Once you've configured your secrets, you can then navigate to the `Actions` tab within your repository. Enable actions for your fork. You can now run the `Sync workflow` manually, or have it automatically run on the schedule set by the `cron` line in the `./github/workflows/sync_peloton_to_garmin.yml` file. 
+
+## Additional Notes
+
+If you're doing more than 5 runs a day, you will need to change the default number of workouts downloaded as part of the workflow.

--- a/src/Peloton/PelotonService.cs
+++ b/src/Peloton/PelotonService.cs
@@ -120,7 +120,7 @@ namespace Peloton
 				}
 
 				_logger.Debug("Check if workout is in ExcludeWorkoutTypes list. {@WorkoutId}", workoutId);
-				if (!_config.Peloton.ExcludeWorkoutTypes?.Contains(deSerializedData.WorkoutType) ?? true)
+				if (_config.Peloton.ExcludeWorkoutTypes.Contains(deSerializedData.WorkoutType))
 				{
 					_logger.Debug("Skipping excluded workout type. {@WorkoutId} {@WorkoutType}", deSerializedData.Workout.Id, deSerializedData.WorkoutType);
 					continue;


### PR DESCRIPTION
This pull-requests adds the ability to automatically sync your Peloton rides with Garmin by simply creating a fork of the repository (and configuring secrets).  Credentials are stored as GitHub Action Secrets and the workflow can be run manually or on a schedule. 

For usage instructions see the markdown file available in this PR.

Additionally fixed a bug with the exclusion predicate being incorrect.