### PR TITLE
changes to docker line to be run (13)

### DIFF
--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -9,8 +9,8 @@ nav_order: 0
 
 The recommended and easiest way to get started is with Docker. To learn more about Docker head on over to their [website](https://www.docker.com/).
 
-```bash
-docker run philosowaffle/peloton-to-garmin:stable -v ./configuration.local.json:/app/configuration.local.json -v ./output:/app/output
+```
+docker run  -v /full/path/to/configuration.local.json:/app/configuration.local.json -v /full/path/to/output:/app/output philosowaffle/peloton-to-garmin:stable
 ```
 
 ## Docker Tags


### PR DESCRIPTION
full path is needed, but also options go before container

I'm not sure about the "bash" piece. It's not showing up on the doc page, so maybe it's harmless. I don't think it's needed though.