### PR TITLE
[#411] webui - fix could not save custom deviceinfo file path

### DIFF
--- a/src/Api/Controllers/SettingsController.cs
+++ b/src/Api/Controllers/SettingsController.cs
@@ -102,7 +102,7 @@ public class SettingsController : Controller
 			return result;
 
 		if (!string.IsNullOrWhiteSpace(updatedFormatSettings.DeviceInfoPath)
-			&& !_fileHandler.DirExists(updatedFormatSettings.DeviceInfoPath))
+			&& !_fileHandler.FileExists(updatedFormatSettings.DeviceInfoPath))
 			return new BadRequestObjectResult(new ErrorResponse($"DeviceInfo path is either not accessible or does not exist."));
 
 		try

--- a/src/Common/FileHandling.cs
+++ b/src/Common/FileHandling.cs
@@ -11,6 +11,7 @@ namespace Common
 	{
 		void MkDirIfNotExists(string path);
 		bool DirExists(string path);
+		bool FileExists(string path);
 		string[] GetFiles(string path);
 
 		T DeserializeJson<T>(string file);
@@ -43,6 +44,14 @@ namespace Common
 			using var trace1 = Tracing.Trace(nameof(DirExists), "io")
 										.WithTag("path", path);
 			return Directory.Exists(path);
+		}
+
+		public bool FileExists(string path)
+		{
+			using var trace1 = Tracing.Trace(nameof(FileExists), "io")
+										.WithTag("path", path);
+			var p = Path.GetFullPath(path);
+			return File.Exists(p);
 		}
 
 		public string[] GetFiles(string path)

--- a/src/UnitTests/Api/Controllers/SettingsControllerTests.cs
+++ b/src/UnitTests/Api/Controllers/SettingsControllerTests.cs
@@ -98,14 +98,14 @@ public class SettingsControllerTests
 	}
 
 	[Test]
-	public async Task FormatPost_With_InvalidOutPutDir_Returns400()
+	public async Task FormatPost_With_InvalidDeviceInfoPath_Returns400()
 	{
 		var autoMocker = new AutoMocker();
 		var controller = autoMocker.CreateInstance<SettingsController>();
 		var fileHandler = autoMocker.GetMock<IFileHandling>();
 
 		fileHandler
-			.Setup(f => f.DirExists("blah"))
+			.Setup(f => f.FileExists("blah"))
 			.Returns(false)
 			.Verifiable();
 

--- a/vNextReleaseNotes.md
+++ b/vNextReleaseNotes.md
@@ -4,3 +4,4 @@
 ## Fixes
 
 - [#404] Fixed where outdoor Just walk/Just run could be missing GPS data on Garmin Connect
+- [#411] WebUI - Fixed issue where custom DeviceInfo file path could not be saved


### PR DESCRIPTION
closes #411 