### PR TITLE
fix(#534): Explicitly define default value for saveLocalCopy

### DIFF
--- a/.github/workflows/sync_peloton_to_garmin.yml
+++ b/.github/workflows/sync_peloton_to_garmin.yml
@@ -91,10 +91,10 @@ jobs:
 
     - name: zip output files 
       if: ${{ github.event.inputs.saveLocalCopy }}
-      run: |
-        zip -r output.zip ${{ env.OUTPUT_DIR }}
+      run: zip -r output.zip ${{ env.OUTPUT_DIR }}
     - uses: actions/upload-artifact@v3
       if: ${{ github.event.inputs.saveLocalCopy }}
       with:
         name: output
         path: output.zip
+        if-no-files-found: error

--- a/.github/workflows/sync_peloton_to_garmin.yml
+++ b/.github/workflows/sync_peloton_to_garmin.yml
@@ -89,9 +89,12 @@ jobs:
         P2G_GARMIN__PASSWORD: ${{ secrets.P2G_GARMIN__PASSWORD }}
         TZ: America/Chicago
 
-    - name: zip output files 
+    - name: zip output files
       if: ${{ github.event.inputs.saveLocalCopy }}
-      run: zip -r output.zip ${{ env.OUTPUT_DIR }}
+      uses: papeloto/action-zip@v1
+      with:
+        files: ${{ env.OUTPUT_DIR }}
+        dest: output.zip
     - uses: actions/upload-artifact@v3
       if: ${{ github.event.inputs.saveLocalCopy }}
       with:

--- a/.github/workflows/sync_peloton_to_garmin.yml
+++ b/.github/workflows/sync_peloton_to_garmin.yml
@@ -88,8 +88,13 @@ jobs:
         P2G_GARMIN__EMAIL: ${{ secrets.P2G_GARMIN__EMAIL }}
         P2G_GARMIN__PASSWORD: ${{ secrets.P2G_GARMIN__PASSWORD }}
         TZ: America/Chicago
+
+    - name: zip output files 
+      if: ${{ github.event.inputs.saveLocalCopy }}
+      run: |
+        zip -r output.zip ${{ env.OUTPUT_DIR }}
     - uses: actions/upload-artifact@v3
       if: ${{ github.event.inputs.saveLocalCopy }}
       with:
         name: output
-        path: ${{ env.OUTPUT_DIR }}/fit/*.fit
+        path: output.zip

--- a/.github/workflows/sync_peloton_to_garmin.yml
+++ b/.github/workflows/sync_peloton_to_garmin.yml
@@ -88,16 +88,8 @@ jobs:
         P2G_GARMIN__EMAIL: ${{ secrets.P2G_GARMIN__EMAIL }}
         P2G_GARMIN__PASSWORD: ${{ secrets.P2G_GARMIN__PASSWORD }}
         TZ: America/Chicago
-
-    - name: zip output files
-      if: ${{ github.event.inputs.saveLocalCopy }}
-      uses: papeloto/action-zip@v1
-      with:
-        files: ${{ env.OUTPUT_DIR }}
-        dest: output.zip
     - uses: actions/upload-artifact@v3
       if: ${{ github.event.inputs.saveLocalCopy }}
       with:
         name: output
-        path: output.zip
-        if-no-files-found: error
+        path: ${{ env.OUTPUT_DIR }}/fit/*.fit

--- a/.github/workflows/sync_peloton_to_garmin.yml
+++ b/.github/workflows/sync_peloton_to_garmin.yml
@@ -48,7 +48,7 @@ jobs:
             "Fit": true,
             "Json": false,
             "Tcx": false,
-            "SaveLocalCopy": ${{ github.event.inputs.saveLocalCopy }},
+            "SaveLocalCopy": ${{ github.event.inputs.saveLocalCopy || false }},
             "IncludeTimeInHRZones": false,
             "IncludeTimeInPowerZones": false,
             "DeviceInfoPath": "./deviceInfo.xml"


### PR DESCRIPTION
When GH Action is triggered by cron - it does not respect input's default settings.

fixes #534