### PR TITLE
workflow_dispatch boolean inputs are not actually booleans

### DIFF
--- a/.github/workflows/sync_peloton_to_garmin.yml
+++ b/.github/workflows/sync_peloton_to_garmin.yml
@@ -90,14 +90,14 @@ jobs:
         TZ: America/Chicago
 
     - name: archive files
-      if: ${{ github.event.inputs.saveLocalCopy }}
+      if: ${{ github.event.inputs.saveLocalCopy == 'true' }}
       run: |
         apt-get update
         apt-get install -y zip
         zip -r -j output.zip ${{ env.OUTPUT_DIR }}
         
     - uses: actions/upload-artifact@v3
-      if: ${{ github.event.inputs.saveLocalCopy }}
+      if: ${{ github.event.inputs.saveLocalCopy == 'true'}}
       with:
         name: output
         path: output.zip

--- a/.github/workflows/sync_peloton_to_garmin.yml
+++ b/.github/workflows/sync_peloton_to_garmin.yml
@@ -90,15 +90,15 @@ jobs:
         TZ: America/Chicago
 
     - name: archive files
-      # saveLocalCopy can be set when workflow action is manually run otherwise it's skipped 
-      if: ${{ github.event.inputs.saveLocalCopy == 'true' || false }}
+      # saveLocalCopy can be set when workflow action is manually run otherwise it's always skipped 
+      if: ${{ github.event.inputs.saveLocalCopy == 'true' }}
       run: |
         apt-get update
         apt-get install -y zip
         zip -r -j output.zip ${{ env.OUTPUT_DIR }}
         
     - uses: actions/upload-artifact@v3
-      if: ${{ github.event.inputs.saveLocalCopy == 'true' || false }}
+      if: ${{ github.event.inputs.saveLocalCopy == 'true' }}
       with:
         name: output
         path: output.zip

--- a/.github/workflows/sync_peloton_to_garmin.yml
+++ b/.github/workflows/sync_peloton_to_garmin.yml
@@ -90,14 +90,15 @@ jobs:
         TZ: America/Chicago
 
     - name: archive files
-      if: ${{ github.event.inputs.saveLocalCopy == 'true' }}
+      # saveLocalCopy can be set when workflow action is manually run otherwise it's skipped 
+      if: ${{ github.event.inputs.saveLocalCopy == 'true' || false }}
       run: |
         apt-get update
         apt-get install -y zip
         zip -r -j output.zip ${{ env.OUTPUT_DIR }}
         
     - uses: actions/upload-artifact@v3
-      if: ${{ github.event.inputs.saveLocalCopy == 'true'}}
+      if: ${{ github.event.inputs.saveLocalCopy == 'true' || false }}
       with:
         name: output
         path: output.zip


### PR DESCRIPTION
Closes #548

Apparently, workflow_dispatch inputs are not actually booleans but are strings.  When running the sync_peloton_to_garmin.yml manually with default inputs the GitHub Action fails. 

I found these two references that back the behavior
1. [Boolean inputs are not actually booleans](https://github.com/actions/runner/issues/1483#top)
2. [GitHub Actions: Passing Boolean input variables to reusable workflow_call](https://medium.com/@sohail.ra5/github-actions-passing-boolean-input-variables-to-reusable-workflow-call-42d39bf7342e)

Converting the check to a string check resolves the manual execution of the workflow.

When the workflow is automatically scheduled the inputs event isn't available and will be evaluated to '' and therefore is always skipped, hopefully an inline comment is helpful.
