### PR TITLE
fix: remove ReadLine from console app when not polling

### DIFF
--- a/mkdocs/docs/configuration/app.md
+++ b/mkdocs/docs/configuration/app.md
@@ -17,7 +17,8 @@ The App Settings provide global settings for the P2G application.
  "App": {
     "EnablePolling": true,
     "PollingIntervalSeconds": 86400,
-    "CheckForUpdates": true
+    "CheckForUpdates": true,
+    "WantFinalReadLineInConsole": true
   }
 ```
 
@@ -28,3 +29,4 @@ The App Settings provide global settings for the P2G application.
 | EnablePolling  | no | `true` | `true` if you wish P2G to run continuously and poll Peloton for new workouts. |
 | PollingIntervalSeconds | no | 86400 | The polling interval in seconds determines how frequently P2G should check for new workouts. Be warned, that setting this to a frequency of hourly or less may get you flagged by Peloton as a bad actor and they may reset your password. The default is set to Daily. |
 | CheckForUpdates | no | `true` | `true` if P2G should check for updates and write a log message if a new release is available. If using the UI this message will display there as well. |
+| WantFinalReadLineInConsole | no | `true` | `true` if the P2G console app should invoke Console.ReadLine() before exiting. This allows users to view any diagnostics or error messages. You may want to set this to `false` if running in a headless container environment. This affects only the console app.|

--- a/src/Common/Dto/Settings.cs
+++ b/src/Common/Dto/Settings.cs
@@ -12,140 +12,142 @@ namespace Common.Dto;
 /// </summary>
 public class Settings
 {
-	public Settings()
-	{
-		App = new ();
-		Format = new ();
-		Peloton = new ();
-		Garmin = new ();
-	}
+    public Settings()
+    {
+        App = new ();
+        Format = new ();
+        Peloton = new ();
+        Garmin = new ();
+    }
 
-	public App App { get; set; }
-	public Format Format { get; set; }
-	public PelotonSettings Peloton { get; set; }
-	public GarminSettings Garmin { get; set; }
+    public App App { get; set; }
+    public Format Format { get; set; }
+    public PelotonSettings Peloton { get; set; }
+    public GarminSettings Garmin { get; set; }
 }
 
 public class App
 {
-	public App()
-	{
-		CheckForUpdates = true;
-		EnablePolling = false;
-		PollingIntervalSeconds = 86400; // 1 day
-	}
+    public App()
+    {
+        CheckForUpdates = true;
+        EnablePolling = false;
+        WantFinalReadLineInConsole = true;
+        PollingIntervalSeconds = 86400; // 1 day
+    }
 
-	public bool EnablePolling { get; set; }
-	public int PollingIntervalSeconds { get; set; }
-	public bool CheckForUpdates { get; set; }
+    public bool EnablePolling { get; set; }
+    public bool WantFinalReadLineInConsole { get; set; }
+    public int PollingIntervalSeconds { get; set; }
+    public bool CheckForUpdates { get; set; }
 
-	public static string DataDirectory => Path.GetFullPath(Path.Join(Statics.DefaultDataDirectory, "data"));
+    public static string DataDirectory => Path.GetFullPath(Path.Join(Statics.DefaultDataDirectory, "data"));
 
-	public string WorkingDirectory => Statics.DefaultTempDirectory;
-	public string OutputDirectory => Statics.DefaultOutputDirectory;
-	public string FailedDirectory => Path.GetFullPath(Path.Join(OutputDirectory, "failed"));
-	public string DownloadDirectory => Path.GetFullPath(Path.Join(WorkingDirectory, "downloaded"));
-	public string UploadDirectory => Path.GetFullPath(Path.Join(WorkingDirectory, "upload"));
+    public string WorkingDirectory => Statics.DefaultTempDirectory;
+    public string OutputDirectory => Statics.DefaultOutputDirectory;
+    public string FailedDirectory => Path.GetFullPath(Path.Join(OutputDirectory, "failed"));
+    public string DownloadDirectory => Path.GetFullPath(Path.Join(WorkingDirectory, "downloaded"));
+    public string UploadDirectory => Path.GetFullPath(Path.Join(WorkingDirectory, "upload"));
 
 
 }
 
 public class Format
 {
-	public Format()
-	{
-		Cycling = new Cycling();
-		Running = new Running();
-		Rowing = new Rowing();
-		Strength = new Strength();
-	}
+    public Format()
+    {
+        Cycling = new Cycling();
+        Running = new Running();
+        Rowing = new Rowing();
+        Strength = new Strength();
+    }
 
-	[JsonIgnore]
-	public static readonly Dictionary<WorkoutType, GarminDeviceInfo> DefaultDeviceInfoSettings = new Dictionary<WorkoutType, GarminDeviceInfo>()
-	{
-		{ WorkoutType.None, GarminDevices.Forerunner945 },
-		{ WorkoutType.Cycling, GarminDevices.TACXDevice },
-		{ WorkoutType.Rowing, GarminDevices.EpixDevice },
-	};
+    [JsonIgnore]
+    public static readonly Dictionary<WorkoutType, GarminDeviceInfo> DefaultDeviceInfoSettings = new Dictionary<WorkoutType, GarminDeviceInfo>()
+    {
+        { WorkoutType.None, GarminDevices.Forerunner945 },
+        { WorkoutType.Cycling, GarminDevices.TACXDevice },
+        { WorkoutType.Rowing, GarminDevices.EpixDevice },
+    };
 
-	public bool Fit { get; set; }
-	public bool Json { get; set; }
-	public bool Tcx { get; set; }
-	public bool SaveLocalCopy { get; set; }
-	public bool IncludeTimeInHRZones { get; set; }
-	public bool IncludeTimeInPowerZones { get; set; }
-	[Obsolete("Use DeviceInfoSettings instead.  Will be removed in P2G v5.")]
-	public string DeviceInfoPath { get; set; }
-	public Dictionary<WorkoutType, GarminDeviceInfo> DeviceInfoSettings { get; set; }
-	public string WorkoutTitleTemplate { get; set; } = "{{PelotonWorkoutTitle}}{{#if PelotonInstructorName}} with {{PelotonInstructorName}}{{/if}}";
-	public Cycling Cycling { get; set; }
-	public Running Running { get; set; }
-	public Rowing Rowing { get; init; }
-	public Strength Strength { get; init; }
+    public bool Fit { get; set; }
+    public bool Json { get; set; }
+    public bool Tcx { get; set; }
+    public bool SaveLocalCopy { get; set; }
+    public bool IncludeTimeInHRZones { get; set; }
+    public bool IncludeTimeInPowerZones { get; set; }
+    [Obsolete("Use DeviceInfoSettings instead.  Will be removed in P2G v5.")]
+    public string DeviceInfoPath { get; set; }
+    public Dictionary<WorkoutType, GarminDeviceInfo> DeviceInfoSettings { get; set; }
+    public string WorkoutTitleTemplate { get; set; } = "{{PelotonWorkoutTitle}}{{#if PelotonInstructorName}} with {{PelotonInstructorName}}{{/if}}";
+    public Cycling Cycling { get; set; }
+    public Running Running { get; set; }
+    public Rowing Rowing { get; init; }
+    public Strength Strength { get; init; }
 }
 
 public record Cycling
 {
-	public PreferredLapType PreferredLapType { get; set; }
+    public PreferredLapType PreferredLapType { get; set; }
 }
 
 public record Running
 {
-	public PreferredLapType PreferredLapType { get; set; }
+    public PreferredLapType PreferredLapType { get; set; }
 }
 
 public record Rowing
 {
-	public PreferredLapType PreferredLapType { get; set; }
+    public PreferredLapType PreferredLapType { get; set; }
 }
 
 public record Strength
 {
-	/// <summary>
-	/// When no Rep information is provided by Peloton, P2G will calculate number
-	/// of reps based on this default value. Example, if your DefaultNumSecondsPerRep is 3,
-	/// and the Exercise duration was 15 seconds, then P2G would credit you with 5 reps for that
-	/// exercise.
-	/// </summary>
-	public int DefaultSecondsPerRep { get; set; } = 3;
+    /// <summary>
+    /// When no Rep information is provided by Peloton, P2G will calculate number
+    /// of reps based on this default value. Example, if your DefaultNumSecondsPerRep is 3,
+    /// and the Exercise duration was 15 seconds, then P2G would credit you with 5 reps for that
+    /// exercise.
+    /// </summary>
+    public int DefaultSecondsPerRep { get; set; } = 3;
 }
 
 public enum PreferredLapType
 {
-	Default = 0,
-	Distance = 1,
-	Class_Segments = 2,
-	Class_Targets = 3
+    Default = 0,
+    Distance = 1,
+    Class_Segments = 2,
+    Class_Targets = 3
 }
 
 public class PelotonSettings : ICredentials
 {
-	public PelotonSettings()
-	{
-		ExcludeWorkoutTypes = new List<WorkoutType>();
-		NumWorkoutsToDownload = 5;
-	}
+    public PelotonSettings()
+    {
+        ExcludeWorkoutTypes = new List<WorkoutType>();
+        NumWorkoutsToDownload = 5;
+    }
 
-	public EncryptionVersion EncryptionVersion { get; set; }
-	public string Email { get; set; }
-	public string Password { get; set; }
-	public int NumWorkoutsToDownload { get; set; }
-	public ICollection<WorkoutType> ExcludeWorkoutTypes { get; set; }
+    public EncryptionVersion EncryptionVersion { get; set; }
+    public string Email { get; set; }
+    public string Password { get; set; }
+    public int NumWorkoutsToDownload { get; set; }
+    public ICollection<WorkoutType> ExcludeWorkoutTypes { get; set; }
 }
 
 public class GarminSettings : ICredentials
 {
-	public EncryptionVersion EncryptionVersion { get; set; }
-	public string Email { get; set; }
-	public string Password { get; set; }
-	public bool TwoStepVerificationEnabled { get; set; }
-	public bool Upload { get; set; }
-	public FileFormat FormatToUpload { get; set; }
+    public EncryptionVersion EncryptionVersion { get; set; }
+    public string Email { get; set; }
+    public string Password { get; set; }
+    public bool TwoStepVerificationEnabled { get; set; }
+    public bool Upload { get; set; }
+    public FileFormat FormatToUpload { get; set; }
 }
 
 public enum FileFormat : byte
 {
-	Fit = 0,
-	Tcx = 1,
-	Json = 2
+    Fit = 0,
+    Tcx = 1,
+    Json = 2
 }

--- a/src/ConsoleClient/Startup.cs
+++ b/src/ConsoleClient/Startup.cs
@@ -18,162 +18,165 @@ using Metrics = Common.Observe.Metrics;
 
 namespace ConsoleClient
 {
-	internal class Startup : BackgroundService
-	{
-		private static readonly ILogger _logger = LogContext.ForClass<Startup>();
-		private static readonly Gauge Health = Prometheus.Metrics.CreateGauge("p2g_health_info", "Health status for P2G.");
-		private static readonly Gauge NextSyncTime = Prometheus.Metrics.CreateGauge("p2g_next_sync_time", "The next time the sync will run in seconds since epoch.");
+    internal class Startup : BackgroundService
+    {
+        private static readonly ILogger _logger = LogContext.ForClass<Startup>();
+        private static readonly Gauge Health = Prometheus.Metrics.CreateGauge("p2g_health_info", "Health status for P2G.");
+        private static readonly Gauge NextSyncTime = Prometheus.Metrics.CreateGauge("p2g_next_sync_time", "The next time the sync will run in seconds since epoch.");
 
-		private readonly ISettingsService _settingsService;
-		private readonly ISyncService _syncService;
-		private readonly IGitHubReleaseCheckService _githubService;
-		private readonly IGarminAuthenticationService _garminAuthService;
+        private readonly ISettingsService _settingsService;
+        private readonly ISyncService _syncService;
+        private readonly IGitHubReleaseCheckService _githubService;
+        private readonly IGarminAuthenticationService _garminAuthService;
 
-		public Startup(ISettingsService settingsService, ISyncService syncService, IGitHubReleaseCheckService gitHubService, IGarminAuthenticationService garminAuthService)
-		{
-			_settingsService = settingsService;
-			_syncService = syncService;
-			_githubService = gitHubService;
+        public Startup(ISettingsService settingsService, ISyncService syncService, IGitHubReleaseCheckService gitHubService, IGarminAuthenticationService garminAuthService)
+        {
+            _settingsService = settingsService;
+            _syncService = syncService;
+            _githubService = gitHubService;
 
-			Logging.LogSystemInformation();
-			_garminAuthService = garminAuthService;
-		}
+            Logging.LogSystemInformation();
+            _garminAuthService = garminAuthService;
+        }
 
-		protected override async Task ExecuteAsync(CancellationToken cancelToken)
-		{
-			_logger.Verbose("Begin.");
+        protected override async Task ExecuteAsync(CancellationToken cancelToken)
+        {
+            _logger.Verbose("Begin.");
 
-			var settings = await _settingsService.GetSettingsAsync();
-			var appConfig = await _settingsService.GetAppConfigurationAsync();
+            var settings = await _settingsService.GetSettingsAsync();
+            var appConfig = await _settingsService.GetAppConfigurationAsync();
 
-			try
-			{
-				PelotonService.ValidateConfig(settings.Peloton);
-				GarminUploader.ValidateConfig(settings);
-				Metrics.ValidateConfig(appConfig.Observability);
-				Tracing.ValidateConfig(appConfig.Observability);
+            try
+            {
+                PelotonService.ValidateConfig(settings.Peloton);
+                GarminUploader.ValidateConfig(settings);
+                Metrics.ValidateConfig(appConfig.Observability);
+                Tracing.ValidateConfig(appConfig.Observability);
 
-				if (settings.App.CheckForUpdates)
-				{
-					var latestReleaseInformation = await _githubService.GetLatestReleaseInformationAsync("philosowaffle", "peloton-to-garmin", Constants.AppVersion);
-					if (latestReleaseInformation.IsReleaseNewerThanInstalledVersion)
-					{
-						_logger.Information("*********************************************");
-						_logger.Information("A new version is available: {@Version}", latestReleaseInformation.LatestVersion);
-						_logger.Information("Release Date: {@ReleaseDate}", latestReleaseInformation.ReleaseDate);
-						_logger.Information("Release Information: {@ReleaseUrl}", latestReleaseInformation.ReleaseUrl);
-						_logger.Information("*********************************************");
+                if (settings.App.CheckForUpdates)
+                {
+                    var latestReleaseInformation = await _githubService.GetLatestReleaseInformationAsync("philosowaffle", "peloton-to-garmin", Constants.AppVersion);
+                    if (latestReleaseInformation.IsReleaseNewerThanInstalledVersion)
+                    {
+                        _logger.Information("*********************************************");
+                        _logger.Information("A new version is available: {@Version}", latestReleaseInformation.LatestVersion);
+                        _logger.Information("Release Date: {@ReleaseDate}", latestReleaseInformation.ReleaseDate);
+                        _logger.Information("Release Information: {@ReleaseUrl}", latestReleaseInformation.ReleaseUrl);
+                        _logger.Information("*********************************************");
 
-						AppMetrics.SyncUpdateAvailableMetric(latestReleaseInformation.IsReleaseNewerThanInstalledVersion, latestReleaseInformation.LatestVersion);
-					}
-				}
-			}
-			catch (Exception ex)
-			{
-				_logger.Error(ex, "Exception during config validation. Please modify your configuration.local.json and relaunch the application.");
-				Health.Set(HealthStatus.Dead);
-				Console.ReadLine();
-				Environment.Exit(-1);
-			}
+                        AppMetrics.SyncUpdateAvailableMetric(latestReleaseInformation.IsReleaseNewerThanInstalledVersion, latestReleaseInformation.LatestVersion);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "Exception during config validation. Please modify your configuration.local.json and relaunch the application.");
+                Health.Set(HealthStatus.Dead);
+                Console.ReadLine();
+                Environment.Exit(-1);
+            }
 
-			Health.Set(HealthStatus.Healthy);
-			await RunAsync(cancelToken);
-		}
+            Health.Set(HealthStatus.Healthy);
+            await RunAsync(cancelToken);
+        }
 
-		private async Task RunAsync(CancellationToken cancelToken)
-		{
-			int exitCode = 0;
+        private async Task RunAsync(CancellationToken cancelToken)
+        {
+            int exitCode = 0;
 
-			var appConfig = await _settingsService.GetAppConfigurationAsync();
+            var appConfig = await _settingsService.GetAppConfigurationAsync();
 
-			Log.Information("*********************************************");
-			using var metrics = Metrics.EnableMetricsServer(appConfig.Observability.Prometheus);
-			using var metricsCollector = Metrics.EnableCollector(appConfig.Observability.Prometheus);
-			using var tracing = Tracing.EnableConsoleTracing(appConfig.Observability.Jaeger);
-			Log.Information("*********************************************");
+            Log.Information("*********************************************");
+            using var metrics = Metrics.EnableMetricsServer(appConfig.Observability.Prometheus);
+            using var metricsCollector = Metrics.EnableCollector(appConfig.Observability.Prometheus);
+            using var tracing = Tracing.EnableConsoleTracing(appConfig.Observability.Jaeger);
+            Log.Information("*********************************************");
 
-			Tracing.Source = new(Statics.TracingService);
-			Metrics.CreateAppInfo();
+            Tracing.Source = new(Statics.TracingService);
+            Metrics.CreateAppInfo();
 
-			var settings = await _settingsService.GetSettingsAsync();
+            var settings = await _settingsService.GetSettingsAsync();
 
-			try
-			{
-				if (settings.Peloton.NumWorkoutsToDownload <= 0)
-				{
-					Console.Write("How many workouts to grab? ");
-					int num = Convert.ToInt32(Console.ReadLine());
-					settings.Peloton.NumWorkoutsToDownload = num;
-				}
+            try
+            {
+                if (settings.Peloton.NumWorkoutsToDownload <= 0)
+                {
+                    Console.Write("How many workouts to grab? ");
+                    int num = Convert.ToInt32(Console.ReadLine());
+                    settings.Peloton.NumWorkoutsToDownload = num;
+                }
 
-				if (settings.Garmin.Upload
-					&& settings.Garmin.TwoStepVerificationEnabled
-					&& !(await _garminAuthService.GarminAuthTokenExistsAndIsValidAsync()))
-				{
-					await _garminAuthService.SignInAsync();
+                if (settings.Garmin.Upload
+                    && settings.Garmin.TwoStepVerificationEnabled
+                    && !(await _garminAuthService.GarminAuthTokenExistsAndIsValidAsync()))
+                {
+                    await _garminAuthService.SignInAsync();
 
-					Console.WriteLine("Detected Garmin Two Factor Enabled. Please check your email or phone for the Security Passcode sent by Garmin.");
-					var mfaCode = string.Empty;
-					var retryCount = 5;
-					while (retryCount > 0 && string.IsNullOrWhiteSpace(mfaCode))
-					{
-						Console.WriteLine("Enter Code: ");
-						mfaCode = Console.ReadLine();
-						retryCount--;
-					}
+                    Console.WriteLine("Detected Garmin Two Factor Enabled. Please check your email or phone for the Security Passcode sent by Garmin.");
+                    var mfaCode = string.Empty;
+                    var retryCount = 5;
+                    while (retryCount > 0 && string.IsNullOrWhiteSpace(mfaCode))
+                    {
+                        Console.WriteLine("Enter Code: ");
+                        mfaCode = Console.ReadLine();
+                        retryCount--;
+                    }
 
-					await _garminAuthService.CompleteMFAAuthAsync(mfaCode);
-				}
+                    await _garminAuthService.CompleteMFAAuthAsync(mfaCode);
+                }
 
-				if (!settings.App.EnablePolling)
-				{
-					await _syncService.SyncAsync(settings.Peloton.NumWorkoutsToDownload);
-					return;
-				}
+                if (!settings.App.EnablePolling)
+                {
+                    await _syncService.SyncAsync(settings.Peloton.NumWorkoutsToDownload);
+                    return;
+                }
 
-				while (!cancelToken.IsCancellationRequested)
-				{
-					settings = await _settingsService.GetSettingsAsync();
+                while (!cancelToken.IsCancellationRequested)
+                {
+                    settings = await _settingsService.GetSettingsAsync();
 
-					if (settings.App.CheckForUpdates)
-					{
-						var latestReleaseInformation = await _githubService.GetLatestReleaseInformationAsync("philosowaffle", "peloton-to-garmin", Constants.AppVersion);
-						if (latestReleaseInformation.IsReleaseNewerThanInstalledVersion)
-						{
-							_logger.Information("*********************************************");
-							_logger.Information("A new version is available: {@Version}", latestReleaseInformation.LatestVersion);
-							_logger.Information("Release Date: {@ReleaseDate}", latestReleaseInformation.ReleaseDate);
-							_logger.Information("Release Information: {@ReleaseUrl}", latestReleaseInformation.ReleaseUrl);
-							_logger.Information("*********************************************");
+                    if (settings.App.CheckForUpdates)
+                    {
+                        var latestReleaseInformation = await _githubService.GetLatestReleaseInformationAsync("philosowaffle", "peloton-to-garmin", Constants.AppVersion);
+                        if (latestReleaseInformation.IsReleaseNewerThanInstalledVersion)
+                        {
+                            _logger.Information("*********************************************");
+                            _logger.Information("A new version is available: {@Version}", latestReleaseInformation.LatestVersion);
+                            _logger.Information("Release Date: {@ReleaseDate}", latestReleaseInformation.ReleaseDate);
+                            _logger.Information("Release Information: {@ReleaseUrl}", latestReleaseInformation.ReleaseUrl);
+                            _logger.Information("*********************************************");
 
-							AppMetrics.SyncUpdateAvailableMetric(latestReleaseInformation.IsReleaseNewerThanInstalledVersion, latestReleaseInformation.LatestVersion);
-						}
-					}
+                            AppMetrics.SyncUpdateAvailableMetric(latestReleaseInformation.IsReleaseNewerThanInstalledVersion, latestReleaseInformation.LatestVersion);
+                        }
+                    }
 
-					var syncResult = await _syncService.SyncAsync(settings.Peloton.NumWorkoutsToDownload);
-					Health.Set(syncResult.SyncSuccess ? HealthStatus.Healthy : HealthStatus.UnHealthy);
+                    var syncResult = await _syncService.SyncAsync(settings.Peloton.NumWorkoutsToDownload);
+                    Health.Set(syncResult.SyncSuccess ? HealthStatus.Healthy : HealthStatus.UnHealthy);
 
-					Log.Information("Done");
-					Log.Information("Sleeping for {@Seconds} seconds...", settings.App.PollingIntervalSeconds);
+                    Log.Information("Done");
+                    Log.Information("Sleeping for {@Seconds} seconds...", settings.App.PollingIntervalSeconds);
 
-					var now = DateTime.UtcNow;
-					var nextRunTime = now.AddSeconds(settings.App.PollingIntervalSeconds);
-					NextSyncTime.Set(new DateTimeOffset(nextRunTime).ToUnixTimeSeconds());
-					Thread.Sleep(settings.App.PollingIntervalSeconds * 1000);
-				}
-			}
-			catch (Exception ex)
-			{
-				_logger.Fatal(ex, "Uncaught Exception");
-				Health.Set(HealthStatus.Dead);
-				exitCode = -2;
-			}
-			finally
-			{
-				_logger.Information("Done.");
-				//Console.ReadLine();
-				Environment.Exit(exitCode);
-			}
-		}
-	}
+                    var now = DateTime.UtcNow;
+                    var nextRunTime = now.AddSeconds(settings.App.PollingIntervalSeconds);
+                    NextSyncTime.Set(new DateTimeOffset(nextRunTime).ToUnixTimeSeconds());
+                    Thread.Sleep(settings.App.PollingIntervalSeconds * 1000);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.Fatal(ex, "Uncaught Exception");
+                Health.Set(HealthStatus.Dead);
+                exitCode = -2;
+            }
+            finally
+            {
+                _logger.Information("Done.");
+                if (settings.App.WantFinalReadLineInConsole)
+                {
+                    Console.ReadLine();
+                }
+                Environment.Exit(exitCode);
+            }
+        }
+    }
 }

--- a/src/ConsoleClient/Startup.cs
+++ b/src/ConsoleClient/Startup.cs
@@ -106,7 +106,7 @@ namespace ConsoleClient
 					settings.Peloton.NumWorkoutsToDownload = num;
 				}
 
-				if (settings.Garmin.Upload 
+				if (settings.Garmin.Upload
 					&& settings.Garmin.TwoStepVerificationEnabled
 					&& !(await _garminAuthService.GarminAuthTokenExistsAndIsValidAsync()))
 				{
@@ -171,7 +171,7 @@ namespace ConsoleClient
 			finally
 			{
 				_logger.Information("Done.");
-				Console.ReadLine();
+				//Console.ReadLine();
 				Environment.Exit(exitCode);
 			}
 		}


### PR DESCRIPTION
the Console app performs a ReadLine before exiting. 
When run headless, with no polling, it may never exit, waiting forever. 

This PR removes the ReadLine. 