### PR TITLE
feat: read config dir from P2G_CONFIG environment variable

### DIFF
--- a/src/ConsoleClient/Program.cs
+++ b/src/ConsoleClient/Program.cs
@@ -30,6 +30,7 @@ Statics.TracingService = Constants.ConsoleAppName;
 using IHost host = CreateHostBuilder(args).Build();
 await host.RunAsync();
 
+
 static IHostBuilder CreateHostBuilder(string[] args)
 {
 	return Host.CreateDefaultBuilder(args)
@@ -38,7 +39,11 @@ static IHostBuilder CreateHostBuilder(string[] args)
 			configBuilder.Sources.Clear();
 
 			var configPath = Environment.CurrentDirectory;
-			if (args.Length > 0) configPath = args[0];
+			String envSpecifiedConfigPath = Environment.GetEnvironmentVariable($"{Constants.EnvironmentVariablePrefix}_CONFIG");
+			if (!String.IsNullOrEmpty(envSpecifiedConfigPath))
+			{
+			  configPath = envSpecifiedConfigPath;
+			}
 
 			Statics.ConfigPath = Path.Join(configPath, "configuration.local.json");
 


### PR DESCRIPTION
This introduces a new environment variable , which tells the console/headless image where it can read the configuration file.
This is handy when running the unmodified image in a serverless container engine like Google Cloud Run. 

Using this feature with the docker image would look like this: 
```
docker run --network=host -i \
    -v /path/to/secrets/headless-config.json:/app/mounted-config/configuration.local.json \
    -v /path/to/host/output:/app/output \
    -e P2G_CONFIG=/app/mounted-config \
    docker.io/library/p2g-console-modified
```

With Cloud Run, mounting two cloud storage buckets, one for config and one for output, using this new feature would look like this (note: this is powershell, so it uses backtick for line continuation and $env:VAR for environment variables): 
```
gcloud run jobs create $env:JOB_NAME `
        --image "us-west1-docker.pkg.dev/$env:PROJECT_ID/docker-images/p2g-console-modified" `
        --tasks 1 `
        --max-retries 1 `
        --region "$env:REGION" `
        --project "$env:PROJECT_ID" `
        --set-env-vars "P2G_CONFIG=/app/mounted-config" `
        --add-volume "name=volume_output,type=cloud-storage,bucket=peloton-to-garmin-output" `
        --add-volume-mount "volume=volume_output,mount-path=/app/output"  `
        --add-volume "name=volume_config,type=cloud-storage,bucket=peloton-to-garmin-config" `
        --add-volume-mount "volume=volume_config,mount-path=/app/mounted-config" `
```
