### PR TITLE
[795] Add ability to configure Peloton Bearer token

### DIFF
--- a/mkdocs/docs/configuration/peloton.md
+++ b/mkdocs/docs/configuration/peloton.md
@@ -36,6 +36,7 @@ The Peloton Settings provide settings related to how P2G should fetch workouts f
 | Email | **yes** | `null` | Your Peloton email used to sign in |
 | Password | **yes** | `null` | Your Peloton password used to sign in. **Note: Does not support `\` character in password** |
 | SessionId | **no** | `null` | Your Peloton sessionId [Read more...](#peloton-session-id) |
+| BearerToken | **no** | `null` | Your Peloton API Bearer Token (excluding the word `Bearer`) [Read more...](#peloton-bearer-token) |
 | NumWorkoutsToDownload | no | 5 | The default number of workouts to download. See [choosing number of workouts to download](#choosing-number-of-workouts-to-download).  Set this to `0` if you would like P2G to prompt you each time for a number to download. |
 | ExcludeWorkoutTypes | no | none | An array of workout types that you do not want P2G to download/convert/upload. [Read more...](#exclude-workout-types) |
 
@@ -66,8 +67,42 @@ Saving the session id in the config file and restarting P2G will cause P2G to us
 
 You will need to manually update this token every time it expires.  In order to stop using the token, simply delete `"SessionId": "..."` from your config file and restart P2G.
 
+!!! note 
+    Windows users, your config file is found in `<Your P2G Folder>/data/SettingsDb.json`.  Quit P2G, edit this file, then start P2G again.
+
 !!! danger 
     SessionId is like a password and should never be shared.
     Github action users should set SessionId as a secret similar to how you configure Email and Password.
 
-!!! warning TODO: Better instructions and the ability to edit this from UI
+!!! warning 
+    TODO: Better instructions and the ability to edit this from UI
+
+## Peloton Bearer Token
+
+In the event P2G is not able to authenticate with Peloton, this configuration field can be used as a fallback option.  If you use this option, you DO NOT need to set `Session Id`, consider this mutually exclusive with `Session Id` authentication.
+
+By visiting the website, and logging in, you can find your Bearer token by inspecting the Network traffic.  Quick, not great instructions on how to do that:
+
+1. Got to Peloton and login
+2. Hit F12 on your keyboard, this should open the Developer Console
+3. Look for a Network tab
+4. Refresh the web page, this should cause new traffic to populate in the Network tab
+5. Look for any item that has domain `api.peloton.com` and single click it
+6. This will open a details pane for that request
+7. Look for the `Headers` tab in the details pane, then look for a Header called `Authorization: Bearer aIdlkjf....`
+8. Copy all of the text AFTER the word `Bearer`
+9. Save that copied text into your P2G config
+
+Saving the Bearer Token in the config file and restarting P2G will cause P2G to use that token for authentication, bypassing the need to "login".
+
+You will need to manually update this token every time it expires.  In order to stop using the token, simply delete `"BearerToken": "..."` from your config file and restart P2G.
+
+!!! note 
+    Windows users, your config file is found in `<Your P2G Folder>/data/SettingsDb.json`.  Quit P2G, edit this file, then start P2G again.
+    
+!!! danger 
+    BearerToken is like a password and should never be shared.
+    Github action users should set BearerToken as a secret similar to how you configure Email and Password.
+
+!!! warning 
+    TODO: Better instructions and the ability to edit this from UI

--- a/src/Common/Constants.cs
+++ b/src/Common/Constants.cs
@@ -9,6 +9,6 @@
 		public const string WebUIName = "p2g_webui";
 		public const string ClientUIName = "p2g_clientui";
 
-		public const string AppVersion = "5.1.0";
+		public const string AppVersion = "5.2.0";
 	}
 }

--- a/src/Common/Dto/Settings.cs
+++ b/src/Common/Dto/Settings.cs
@@ -146,6 +146,7 @@ public class PelotonSettings : ICredentials
 	public string Email { get; set; }
 	public string Password { get; set; }
 	public string SessionId { get; set; }
+	public string BearerToken { get; set; }
 	public int NumWorkoutsToDownload { get; set; }
 	public ICollection<WorkoutType> ExcludeWorkoutTypes { get; set; }
 }

--- a/src/Common/Stateful/PelotonApiAuthentication.cs
+++ b/src/Common/Stateful/PelotonApiAuthentication.cs
@@ -8,6 +8,7 @@ namespace Common.Stateful
 		public string Password { get; set; }
 		public string UserId { get; set; }
 		public string SessionId { get; set; }
+		public string BearerToken { get; set; }
 
 		public bool IsValid(Settings settings)
 		{

--- a/src/Peloton/ApiClient.cs
+++ b/src/Peloton/ApiClient.cs
@@ -20,7 +20,7 @@ namespace Peloton
 		Task<PelotonResponse<Workout>> GetWorkoutsAsync(DateTime fromUtc, DateTime toUtc);
 		Task<Workout> GetWorkoutByIdAsync(string id);
 		Task<WorkoutSamples> GetWorkoutSamplesByIdAsync(string id);
-		Task<UserData> GetUserDataAsync(string sessionId = null);
+		Task<UserData> GetUserDataAsync(string sessionId = null, string bearerToken = null);
 		Task<PelotonChallenges> GetJoinedChallengesAsync(int userId);
 		Task<PelotonUserChallengeDetail> GetUserChallengeDetailsAsync(int userId, string challengeId);
 		Task<RideSegments> GetClassSegmentsAsync(string rideId);
@@ -53,6 +53,18 @@ namespace Peloton
 				};
 
 				var userData = await GetUserDataAsync(userProvidedAuth.SessionId);
+				userProvidedAuth.UserId = userData.Id;
+				return userProvidedAuth;
+            }
+
+			if (!string.IsNullOrWhiteSpace(settings.Peloton.BearerToken))
+            {
+                var userProvidedAuth = new PelotonApiAuthentication()
+				{
+					BearerToken = settings.Peloton.BearerToken
+				};
+
+				var userData = await GetUserDataAsync(sessionId: "", bearerToken: userProvidedAuth.BearerToken);
 				userProvidedAuth.UserId = userData.Id;
 				return userProvidedAuth;
             }
@@ -103,6 +115,7 @@ namespace Peloton
 			var auth = await GetAuthAsync();
 			return await $"{BaseUrl}/user/{auth.UserId}/workouts"
 			.WithCookie("peloton_session_id", auth.SessionId)
+			.WithOAuthBearerToken(auth.BearerToken)
 			.WithCommonHeaders()
 			.SetQueryParams(new
 			{
@@ -119,6 +132,7 @@ namespace Peloton
 			var auth = await GetAuthAsync();
 			return await $"{BaseUrl}/user/{auth.UserId}/workouts"
 			.WithCookie("peloton_session_id", auth.SessionId)
+			.WithOAuthBearerToken(auth.BearerToken)
 			.WithCommonHeaders()
 			.SetQueryParams(new
 			{
@@ -138,6 +152,7 @@ namespace Peloton
 			var auth = await GetAuthAsync();
 			return await $"{BaseUrl}/user/{userId}/workouts"
 			.WithCookie("peloton_session_id", auth.SessionId)
+			.WithOAuthBearerToken(auth.BearerToken)
 			.WithCommonHeaders()
 			.SetQueryParams(new
 			{
@@ -157,6 +172,7 @@ namespace Peloton
 			var auth = await GetAuthAsync();
 			return await $"{BaseUrl}/workout/{id}"
 				.WithCookie("peloton_session_id", auth.SessionId)
+				.WithOAuthBearerToken(auth.BearerToken)
 				.WithCommonHeaders()
 				.SetQueryParams(new
 				{
@@ -173,6 +189,7 @@ namespace Peloton
 			var auth = await GetAuthAsync();
 			return await $"{BaseUrl}/workout/{id}/performance_graph"
 				.WithCookie("peloton_session_id", auth.SessionId)
+				.WithOAuthBearerToken(auth.BearerToken)
 				.WithCommonHeaders()
 				.SetQueryParams(new
 				{
@@ -189,15 +206,18 @@ namespace Peloton
 			var auth = await GetAuthAsync();
 			return await $"{BaseUrl}/ride/{rideId}/details"
 				.WithCookie("peloton_session_id", auth.SessionId)
+				.WithOAuthBearerToken(auth.BearerToken)
 				.WithCommonHeaders()
 				.GetStringAsync();
 		}
 
-		public async Task<UserData> GetUserDataAsync(string sessionId = null)
+		public async Task<UserData> GetUserDataAsync(string sessionId = null, string bearerToken = null)
 		{
 			var sid = sessionId ?? (await GetAuthAsync()).SessionId;
+			var bearer = bearerToken ?? (await GetAuthAsync()).BearerToken;
 			return await $"{BaseUrl}/me"
 			.WithCookie("peloton_session_id", sid)
+			.WithOAuthBearerToken(bearer)
 			.WithCommonHeaders()
 			.GetJsonAsync<UserData>();
 		}
@@ -207,6 +227,7 @@ namespace Peloton
 			var auth = await GetAuthAsync();
 			return await $"{BaseUrl}/workout/{id}"
 				.WithCookie("peloton_session_id", auth.SessionId)
+				.WithOAuthBearerToken(auth.BearerToken)
 				.WithCommonHeaders()
 				.SetQueryParams(new
 				{
@@ -220,6 +241,7 @@ namespace Peloton
 			var auth = await GetAuthAsync();
 			return await $"{BaseUrl}/workout/{id}/performance_graph"
 				.WithCookie("peloton_session_id", auth.SessionId)
+				.WithOAuthBearerToken(auth.BearerToken)
 				.WithCommonHeaders()
 				.SetQueryParams(new
 				{
@@ -233,6 +255,7 @@ namespace Peloton
 			var auth = await GetAuthAsync();
 			return await $"{BaseUrl}/user/{auth.UserId}/challenges/current"
 				.WithCookie("peloton_session_id", auth.SessionId)
+				.WithOAuthBearerToken(auth.BearerToken)
 				.WithCommonHeaders()
 				.SetQueryParams(new
 				{
@@ -246,6 +269,7 @@ namespace Peloton
 			var auth = await GetAuthAsync();
 			return await $"{BaseUrl}/user/{auth.UserId}/challenge/{challengeId}"
 				.WithCookie("peloton_session_id", auth.SessionId)
+				.WithOAuthBearerToken(auth.BearerToken)
 				.WithCommonHeaders()
 				.GetJsonAsync<PelotonUserChallengeDetail>();
 		}
@@ -255,6 +279,7 @@ namespace Peloton
 			var auth = await GetAuthAsync();
 			return await $"{BaseUrl}/ride/{rideId}/details"
 				.WithCookie("peloton_session_id", auth.SessionId)
+				.WithOAuthBearerToken(auth.BearerToken)
 				.WithCommonHeaders()
 				.GetJsonAsync<RideSegments>();
 		}

--- a/vNextReleaseNotes.md
+++ b/vNextReleaseNotes.md
@@ -4,29 +4,25 @@
 > [!TIP]
 > You can find specific Upgrade Instructions by visitng the [Install Page](https://philosowaffle.github.io/peloton-to-garmin/latest/install/) for your particular flavor of P2G and looking for the section titled `⬆️ Updating`.
 
-## Fixes
-
-- [#795] Temporarily fixes Peloton API error
-
 ## Features
 
-- [#795] Add ability to provide Peloton Session Id via config file (@eRaid6)
+- [#795] Add ability to provide Peloton Bearer Token via config file (@eRaid6)
 
 ## Docker Tags
 
 - Console
     - `console-stable`
     - `console-latest`
-    - `console-v5.1.0`
+    - `console-v5.2.0`
     - `console-v5`
 
 - Api
     - `api-stable`
     - `api-latest`
-    - `api-v5.1.0`
+    - `api-v5.2.0`
     - `api-v5`
 - WebUI
     - `webui-stable`
     - `webui-latest`
-    - `webui-v5.1.0`
+    - `webui-v5.2.0`
     - `webui-v5`


### PR DESCRIPTION
Similar to Session Id, Bearer Token can now be configured via config file.