### PR TITLE
ConsoleClient graceful exit when user cancels operation

### DIFF
--- a/src/ConsoleClient/Startup.cs
+++ b/src/ConsoleClient/Startup.cs
@@ -162,7 +162,16 @@ namespace ConsoleClient
 					var now = DateTime.UtcNow;
 					var nextRunTime = now.AddSeconds(settings.App.PollingIntervalSeconds);
 					NextSyncTime.Set(new DateTimeOffset(nextRunTime).ToUnixTimeSeconds());
-					Thread.Sleep(settings.App.PollingIntervalSeconds * 1000);
+					
+					try
+					{
+						await Task.Delay(settings.App.PollingIntervalSeconds * 1000, cancelToken);
+					}
+					catch (OperationCanceledException)
+					{
+						_logger.Information("Shutdown requested. Exiting gracefully...");
+						return;
+					}
 				}
 			}
 			catch (Exception ex)


### PR DESCRIPTION
ConsoleClient does not current exit gracefully when cancelling the operation via `Ctrl+C`. This small change implements graceful exit.

Previous state:
<img width="582" height="224" alt="image" src="https://github.com/user-attachments/assets/be6314fa-af04-4651-913a-3da268a07dc0" />

New state:
<img width="579" height="129" alt="image" src="https://github.com/user-attachments/assets/39e297a0-bdb1-4416-b03f-ccc60bc0329e" />
