### PR TITLE
Update AnnualChallengeId for 2026

### DIFF
--- a/src/Peloton/AnnualChallenge/AnnualChallengeService.cs
+++ b/src/Peloton/AnnualChallenge/AnnualChallengeService.cs
@@ -12,7 +12,7 @@ public interface IAnnualChallengeService
 
 public class AnnualChallengeService : IAnnualChallengeService
 {
-	private const string AnnualChallengeId = "fa65351309d6476a8aadcc53902d78ec";
+	private const string AnnualChallengeId = "67bfab351b6f4e239ed17aadf28c006e";
 
 	private IPelotonApi _pelotonApi;
 


### PR DESCRIPTION
Pull request to resolve Issue 812 (https://github.com/philosowaffle/peloton-to-garmin/issues/812)

Updating the AnnualChallengeId for 2026 in AnnualChallengeService.cs => 67bfab351b6f4e239ed17aadf28c006e

